### PR TITLE
fix(tools): persist run log so it survives popup focus loss

### DIFF
--- a/tools/stats-collector/background.js
+++ b/tools/stats-collector/background.js
@@ -489,6 +489,27 @@ async function runCollection(config, token, onProgress) {
   }
 }
 
+// ── persistent run log ──────────────────────────────────────────────────────
+// The popup window is destroyed whenever it loses focus, taking its in-DOM log
+// with it. So the background owns the log: every line is mirrored to
+// storage.local, which survives popup close (and service-worker restarts) and
+// is broadcast to the popup live via chrome.storage.onChanged. Starting a run
+// clears the buffer, so relaunching an action wipes the previous output.
+
+let runLog = [];
+
+function pushLog(text, cls, state) {
+  runLog.push(cls ? { text, cls } : { text });
+  const data = { run_log: runLog };
+  if (state) data.run_state = state;
+  chrome.storage.local.set(data);
+}
+
+function resetLog() {
+  runLog = [];
+  chrome.storage.local.set({ run_log: runLog, run_state: 'running' });
+}
+
 // ── message handler ───────────────────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
@@ -496,12 +517,14 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
   const { config, token } = msg;
   (async () => {
+    resetLog();
+    pushLog('Starting…');
     try {
-      const progress = status =>
-        chrome.runtime.sendMessage({ type: 'PROGRESS', status }).catch(() => {});
-      await runCollection(config, token, progress);
+      await runCollection(config, token, status => pushLog(status));
+      pushLog('Done.', 'ok', 'done');
       sendResponse({ ok: true });
     } catch (e) {
+      pushLog('Error: ' + e.message, 'err', 'error');
       sendResponse({ ok: false, error: e.message });
     }
   })();

--- a/tools/stats-collector/popup.js
+++ b/tools/stats-collector/popup.js
@@ -2,7 +2,24 @@ const patInput = document.getElementById('pat');
 const runBtn   = document.getElementById('run');
 const logEl    = document.getElementById('log');
 
-function appendLog(text, cls) {
+// Rebuild the log view from the persisted buffer. The background owns the log
+// (see background.js): rendering purely from storage means focus loss — which
+// destroys this popup — never loses output, and reopening restores it.
+function renderLog(log) {
+  logEl.textContent = '';
+  if (!log || !log.length) { logEl.style.display = 'none'; return; }
+  logEl.style.display = 'block';
+  for (const { text, cls } of log) {
+    const line = document.createElement('div');
+    if (cls) line.className = cls;
+    line.textContent = text;
+    logEl.appendChild(line);
+  }
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+// Local-only notice (e.g. input validation) that never reaches the background.
+function appendLocal(text, cls) {
   logEl.style.display = 'block';
   const line = document.createElement('div');
   if (cls) line.className = cls;
@@ -21,35 +38,37 @@ function setRunning(busy) {
   runBtn.disabled = busy;
 }
 
-chrome.storage.local.get('github_pat', ({ github_pat }) => {
+// Hydrate from storage: restore the PAT and any log from a previous (possibly
+// still-running) run, and reflect whether a run is currently in progress.
+chrome.storage.local.get(['github_pat', 'run_log', 'run_state'], ({ github_pat, run_log, run_state }) => {
   if (github_pat) patInput.value = github_pat;
+  renderLog(run_log);
+  setRunning(run_state === 'running');
+});
+
+// Live updates from the background, broadcast even while the popup was closed.
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'local') return;
+  if (changes.run_log)   renderLog(changes.run_log.newValue);
+  if (changes.run_state) setRunning(changes.run_state.newValue === 'running');
 });
 
 runBtn.addEventListener('click', () => {
   const token = patInput.value.trim();
-  if (!token) { appendLog('Enter a GitHub PAT first.', 'err'); return; }
+  if (!token) { appendLocal('Enter a GitHub PAT first.', 'err'); return; }
 
   chrome.storage.local.set({ github_pat: token });
-
-  logEl.textContent = '';
-  logEl.style.display = 'block';
   setRunning(true);
-  appendLog('Starting…');
 
   loadConfig()
     .then(config => {
-      const onMsg = msg => { if (msg.type === 'PROGRESS') appendLog(msg.status); };
-      chrome.runtime.onMessage.addListener(onMsg);
-
-      chrome.runtime.sendMessage({ type: 'START_COLLECTION', config, token }, resp => {
-        chrome.runtime.onMessage.removeListener(onMsg);
-        setRunning(false);
-        if (!resp) { appendLog('No response from background.', 'err'); return; }
-        appendLog(resp.ok ? 'Done.' : 'Error: ' + resp.error, resp.ok ? 'ok' : 'err');
-      });
+      // Progress and the final result are reflected via storage.local, so the
+      // sendMessage callback is not needed (it would be dropped if the popup
+      // closed before the run finished).
+      chrome.runtime.sendMessage({ type: 'START_COLLECTION', config, token }, () => {});
     })
     .catch(e => {
-      appendLog(e.message, 'err');
+      appendLocal(e.message, 'err');
       setRunning(false);
     });
 });

--- a/tools/store-publisher/background.js
+++ b/tools/store-publisher/background.js
@@ -251,18 +251,41 @@ async function runPublish(config, opts, onProgress) {
   onProgress('All done. Review the page, then click "Save draft" yourself — nothing has been saved.');
 }
 
+// ── persistent run log ──────────────────────────────────────────────────────
+// The popup window is destroyed whenever it loses focus, taking its in-DOM log
+// with it. So the background owns the log: every line is mirrored to
+// storage.local, which survives popup close (and service-worker restarts) and
+// is broadcast to the popup live via chrome.storage.onChanged. Starting a run
+// clears the buffer, so relaunching an action wipes the previous output.
+
+let runLog = [];
+
+function pushLog(text, cls, state) {
+  runLog.push(cls ? { text, cls } : { text });
+  const data = { run_log: runLog };
+  if (state) data.run_state = state;
+  chrome.storage.local.set(data);
+}
+
+function resetLog() {
+  runLog = [];
+  chrome.storage.local.set({ run_log: runLog, run_state: 'running' });
+}
+
 // ── message handler ───────────────────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type !== 'START_PUBLISH') return;
   const { config, opts } = msg;
   (async () => {
+    resetLog();
+    pushLog(opts.probeOnly ? 'Probing…' : 'Starting…');
     try {
-      const progress = status =>
-        chrome.runtime.sendMessage({ type: 'PROGRESS', status }).catch(() => {});
-      await runPublish(config, opts, progress);
+      await runPublish(config, opts, status => pushLog(status));
+      pushLog('Done.', 'ok', 'done');
       sendResponse({ ok: true });
     } catch (e) {
+      pushLog('Error: ' + e.message, 'err', 'error');
       sendResponse({ ok: false, error: e.message });
     }
   })();

--- a/tools/store-publisher/popup.js
+++ b/tools/store-publisher/popup.js
@@ -8,7 +8,24 @@ const runBtn     = document.getElementById('run');
 const probeBtn   = document.getElementById('probe');
 const logEl      = document.getElementById('log');
 
-function appendLog(text, cls) {
+// Rebuild the log view from the persisted buffer. The background owns the log
+// (see background.js): rendering purely from storage means focus loss — which
+// destroys this popup — never loses output, and reopening restores it.
+function renderLog(log) {
+  logEl.textContent = '';
+  if (!log || !log.length) { logEl.style.display = 'none'; return; }
+  logEl.style.display = 'block';
+  for (const { text, cls } of log) {
+    const line = document.createElement('div');
+    if (cls) line.className = cls;
+    line.textContent = text;
+    logEl.appendChild(line);
+  }
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+// Local-only notice (e.g. config-load failure) that never reaches the background.
+function appendLocal(text, cls) {
   logEl.style.display = 'block';
   const line = document.createElement('div');
   if (cls) line.className = cls;
@@ -42,27 +59,20 @@ function currentOpts(probeOnly) {
 }
 
 function start(probeOnly) {
-  logEl.textContent = '';
   setRunning(true);
-  appendLog(probeOnly ? 'Probing…' : 'Starting…');
 
   loadConfig()
     .then(config => {
       const opts = currentOpts(probeOnly);
       chrome.storage.local.set({ publisher_opts: opts });
 
-      const onMsg = msg => { if (msg.type === 'PROGRESS') appendLog(msg.status); };
-      chrome.runtime.onMessage.addListener(onMsg);
-
-      chrome.runtime.sendMessage({ type: 'START_PUBLISH', config, opts }, resp => {
-        chrome.runtime.onMessage.removeListener(onMsg);
-        setRunning(false);
-        if (!resp) { appendLog('No response from background.', 'err'); return; }
-        appendLog(resp.ok ? 'Done.' : 'Error: ' + resp.error, resp.ok ? 'ok' : 'err');
-      });
+      // Progress and the final result are reflected via storage.local, so the
+      // sendMessage callback is not needed (it would be dropped if the popup
+      // closed before the run finished).
+      chrome.runtime.sendMessage({ type: 'START_PUBLISH', config, opts }, () => {});
     })
     .catch(e => {
-      appendLog(e.message, 'err');
+      appendLocal(e.message, 'err');
       setRunning(false);
     });
 }
@@ -70,7 +80,15 @@ function start(probeOnly) {
 runBtn.addEventListener('click', () => start(false));
 probeBtn.addEventListener('click', () => start(true));
 
-// Populate the item dropdown from config and restore the last-used options.
+// Live updates from the background, broadcast even while the popup was closed.
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'local') return;
+  if (changes.run_log)   renderLog(changes.run_log.newValue);
+  if (changes.run_state) setRunning(changes.run_state.newValue === 'running');
+});
+
+// Populate the item dropdown from config, restore the last-used options, and
+// restore any log from a previous (possibly still-running) run.
 loadConfig()
   .then(config => {
     for (const item of config.items) {
@@ -79,14 +97,17 @@ loadConfig()
       opt.textContent = item.name;
       itemSel.appendChild(opt);
     }
-    chrome.storage.local.get('publisher_opts', ({ publisher_opts: saved }) => {
-      if (!saved) return;
-      if (config.items.some(i => i.slug === saved.itemSlug)) itemSel.value = saved.itemSlug;
-      optTexts.checked  = saved.updateTexts !== false;
-      optImages.checked = !!saved.updateImages;
-      optGlobal.checked = !!saved.updateGlobalImages;
-      optDryRun.checked = !!saved.dryRun;
-      filterIn.value    = saved.localeFilter || '';
+    chrome.storage.local.get(['publisher_opts', 'run_log', 'run_state'], ({ publisher_opts: saved, run_log, run_state }) => {
+      if (saved) {
+        if (config.items.some(i => i.slug === saved.itemSlug)) itemSel.value = saved.itemSlug;
+        optTexts.checked  = saved.updateTexts !== false;
+        optImages.checked = !!saved.updateImages;
+        optGlobal.checked = !!saved.updateGlobalImages;
+        optDryRun.checked = !!saved.dryRun;
+        filterIn.value    = saved.localeFilter || '';
+      }
+      renderLog(run_log);
+      setRunning(run_state === 'running');
     });
   })
-  .catch(e => appendLog(e.message, 'err'));
+  .catch(e => appendLocal(e.message, 'err'));


### PR DESCRIPTION
## Problem

The `stats-collector` and `store-publisher` maintainer tools showed their action log only in the popup's DOM, with progress delivered via `chrome.runtime.sendMessage`. When the popup lost focus, Chrome destroyed it — tearing down the DOM and the message listener. Any progress (and the final result) emitted while the popup was closed was lost, even though the background run kept going. Reopening the popup showed an empty log.

## Fix

Make the background the source of truth for the run log:

- **`background.js`** (both tools): a small `runLog` buffer is mirrored to `storage.local` (`run_log` + `run_state`) on every line. This survives popup close *and* service-worker restarts. Starting an action calls `resetLog()`, so relaunching wipes the previous output. The final `Done.` / `Error:` line is now written by the background, not a (possibly dead) popup.
- **`popup.js`** (both tools): renders purely from storage — hydrates `run_log`/`run_state` on open and subscribes to `chrome.storage.onChanged` for live updates that arrive even if the popup was closed mid-run. The run button reflects whether a run is still in progress. A local-only `appendLocal()` remains for non-background notices (PAT validation, `config.json` load failure).

## Result

- Log no longer disappears on focus loss; it is restored on reopen and keeps streaming live.
- Relaunching an action automatically clears the previous log.

Maintainer-only tools, outside the build — nothing to rebuild. `npx jest` green (239/239).

🤖 Generated with [Claude Code](https://claude.com/claude-code)