### PR TITLE
fix(af): Meta AI title extraction and '#' trigger degradation

### DIFF
--- a/extensions/ai-folders/site-config.js
+++ b/extensions/ai-folders/site-config.js
@@ -105,6 +105,9 @@ const SITES = {
     newConvUrl: 'https://www.meta.ai/',
     // Meta AI uses a Lexical contenteditable composer; selectors need live validation
     editorSelectors: ['div[contenteditable="true"][role="textbox"]', 'textarea[placeholder]', 'textarea', '[contenteditable="true"]'],
+    // Lexical mangles the multi-line inline-suggestion injection (newlines
+    // collapsed, '#' duplicated) — inject exact matches only, after clearing
+    forceClear: true,
     logo: 'icons/meta.png',
   },
   mistral: {
@@ -336,6 +339,24 @@ function extractAITitleLogic(siteKey, defaultFallback) {
       () => docTitle(new Set(['perplexity', 'perplexity ai', 'perplexity.ai', ''])),
       () => firstMsg('[data-testid="query-text"], .query, .prose p:first-child'),
     ];
+  } else if (siteKey === 'meta') {
+    // No generic activeSidebarLink here: Meta's [aria-current] element is the
+    // sidebar date group header ("Today"), not the conversation entry.
+    fallbackIgnores = new Set(['meta ai', 'meta.ai', 'new conversation', 'today', 'yesterday', '']);
+    strategies = [
+      // Active conversation in the sidebar history:
+      // <a data-sidebar="menu-button" data-active="true"><span class="truncate">…
+      () => document.querySelector('a[data-sidebar="menu-button"][data-active="true"] .truncate')?.textContent?.trim() || null,
+      // Conversation title button in the page header:
+      // <button data-slot="button"><span class="truncate">… — filtered, since
+      // other header buttons share the same markup
+      () => {
+        const t = document.querySelector('header button[data-slot="button"] span.truncate')?.textContent?.trim();
+        return (t && t.length > 1 && !fallbackIgnores.has(t.toLowerCase())) ? t : null;
+      },
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
   } else if (siteKey === 'baidu') {
     fallbackIgnores = new Set(['baidu', 'baidu chat', 'ai chat', '文心一言', '百度文心助手', '文心助手', 'new chat', '']);
     strategies = [
@@ -354,7 +375,6 @@ function extractAITitleLogic(siteKey, defaultFallback) {
     const genericIgnores = {
       zai: ['z.ai', 'chat.z.ai', 'new chat'],
       qwen: ['qwen', 'qwen chat', 'new chat'],
-      meta: ['meta ai', 'meta.ai', 'new conversation'],
       mistral: ['le chat', 'le chat - mistral ai', 'mistral ai', 'new chat'],
       poe: ['poe', 'new chat'],
       duckai: ['duckduckgo ai chat', 'duckduckgo', 'ai chat', 'duck.ai'],

--- a/tests/site-config.test.js
+++ b/tests/site-config.test.js
@@ -134,6 +134,29 @@ describe('extractAITitleLogic', () => {
     expect(extractAITitleLogic('characterai', 'New conversation')).toBe('New conversation');
   });
 
+  test('meta: does NOT read the sidebar date group header ("Today")', () => {
+    document.body.innerHTML = '<a aria-current="page"><span>Today</span></a>';
+    expect(extractAITitleLogic('meta', 'fallback')).toBe('fallback');
+  });
+
+  test('meta: reads the active sidebar conversation link', () => {
+    document.body.innerHTML =
+      '<a href="/prompt/x" data-sidebar="menu-button"><span class="min-w-0 flex-1 truncate">Autre</span></a>' +
+      '<a href="/prompt/y" data-sidebar="menu-button" data-active="true"><span class="min-w-0 flex-1 truncate">Quick Hello</span></a>';
+    expect(extractAITitleLogic('meta', 'fallback')).toBe('Quick Hello');
+  });
+
+  test('meta: reads the header title button, skipping generic labels', () => {
+    document.body.innerHTML =
+      '<header><button data-slot="button"><span class="truncate">Quick Hello</span></button></header>';
+    expect(extractAITitleLogic('meta', 'fallback')).toBe('Quick Hello');
+  });
+
+  test('meta: uses the document <title> when it is a real conversation name', () => {
+    document.title = 'Trip planning - Meta AI';
+    expect(extractAITitleLogic('meta', 'fallback')).toBe('Trip planning');
+  });
+
   test('baidu: reads the selected sidebar history item', () => {
     document.body.innerHTML =
       '<div class="chat-side-list-item">' +

--- a/tools/site-diagnostics/firefox/site-config.js
+++ b/tools/site-diagnostics/firefox/site-config.js
@@ -105,6 +105,9 @@ const SITES = {
     newConvUrl: 'https://www.meta.ai/',
     // Meta AI uses a Lexical contenteditable composer; selectors need live validation
     editorSelectors: ['div[contenteditable="true"][role="textbox"]', 'textarea[placeholder]', 'textarea', '[contenteditable="true"]'],
+    // Lexical mangles the multi-line inline-suggestion injection (newlines
+    // collapsed, '#' duplicated) — inject exact matches only, after clearing
+    forceClear: true,
     logo: 'icons/meta.png',
   },
   mistral: {
@@ -336,6 +339,24 @@ function extractAITitleLogic(siteKey, defaultFallback) {
       () => docTitle(new Set(['perplexity', 'perplexity ai', 'perplexity.ai', ''])),
       () => firstMsg('[data-testid="query-text"], .query, .prose p:first-child'),
     ];
+  } else if (siteKey === 'meta') {
+    // No generic activeSidebarLink here: Meta's [aria-current] element is the
+    // sidebar date group header ("Today"), not the conversation entry.
+    fallbackIgnores = new Set(['meta ai', 'meta.ai', 'new conversation', 'today', 'yesterday', '']);
+    strategies = [
+      // Active conversation in the sidebar history:
+      // <a data-sidebar="menu-button" data-active="true"><span class="truncate">…
+      () => document.querySelector('a[data-sidebar="menu-button"][data-active="true"] .truncate')?.textContent?.trim() || null,
+      // Conversation title button in the page header:
+      // <button data-slot="button"><span class="truncate">… — filtered, since
+      // other header buttons share the same markup
+      () => {
+        const t = document.querySelector('header button[data-slot="button"] span.truncate')?.textContent?.trim();
+        return (t && t.length > 1 && !fallbackIgnores.has(t.toLowerCase())) ? t : null;
+      },
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
   } else if (siteKey === 'baidu') {
     fallbackIgnores = new Set(['baidu', 'baidu chat', 'ai chat', '文心一言', '百度文心助手', '文心助手', 'new chat', '']);
     strategies = [
@@ -354,7 +375,6 @@ function extractAITitleLogic(siteKey, defaultFallback) {
     const genericIgnores = {
       zai: ['z.ai', 'chat.z.ai', 'new chat'],
       qwen: ['qwen', 'qwen chat', 'new chat'],
-      meta: ['meta ai', 'meta.ai', 'new conversation'],
       mistral: ['le chat', 'le chat - mistral ai', 'mistral ai', 'new chat'],
       poe: ['poe', 'new chat'],
       duckai: ['duckduckgo ai chat', 'duckduckgo', 'ai chat', 'duck.ai'],

--- a/tools/site-diagnostics/site-config.js
+++ b/tools/site-diagnostics/site-config.js
@@ -105,6 +105,9 @@ const SITES = {
     newConvUrl: 'https://www.meta.ai/',
     // Meta AI uses a Lexical contenteditable composer; selectors need live validation
     editorSelectors: ['div[contenteditable="true"][role="textbox"]', 'textarea[placeholder]', 'textarea', '[contenteditable="true"]'],
+    // Lexical mangles the multi-line inline-suggestion injection (newlines
+    // collapsed, '#' duplicated) — inject exact matches only, after clearing
+    forceClear: true,
     logo: 'icons/meta.png',
   },
   mistral: {
@@ -336,6 +339,24 @@ function extractAITitleLogic(siteKey, defaultFallback) {
       () => docTitle(new Set(['perplexity', 'perplexity ai', 'perplexity.ai', ''])),
       () => firstMsg('[data-testid="query-text"], .query, .prose p:first-child'),
     ];
+  } else if (siteKey === 'meta') {
+    // No generic activeSidebarLink here: Meta's [aria-current] element is the
+    // sidebar date group header ("Today"), not the conversation entry.
+    fallbackIgnores = new Set(['meta ai', 'meta.ai', 'new conversation', 'today', 'yesterday', '']);
+    strategies = [
+      // Active conversation in the sidebar history:
+      // <a data-sidebar="menu-button" data-active="true"><span class="truncate">…
+      () => document.querySelector('a[data-sidebar="menu-button"][data-active="true"] .truncate')?.textContent?.trim() || null,
+      // Conversation title button in the page header:
+      // <button data-slot="button"><span class="truncate">… — filtered, since
+      // other header buttons share the same markup
+      () => {
+        const t = document.querySelector('header button[data-slot="button"] span.truncate')?.textContent?.trim();
+        return (t && t.length > 1 && !fallbackIgnores.has(t.toLowerCase())) ? t : null;
+      },
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
   } else if (siteKey === 'baidu') {
     fallbackIgnores = new Set(['baidu', 'baidu chat', 'ai chat', '文心一言', '百度文心助手', '文心助手', 'new chat', '']);
     strategies = [
@@ -354,7 +375,6 @@ function extractAITitleLogic(siteKey, defaultFallback) {
     const genericIgnores = {
       zai: ['z.ai', 'chat.z.ai', 'new chat'],
       qwen: ['qwen', 'qwen chat', 'new chat'],
-      meta: ['meta ai', 'meta.ai', 'new conversation'],
       mistral: ['le chat', 'le chat - mistral ai', 'mistral ai', 'new chat'],
       poe: ['poe', 'new chat'],
       duckai: ['duckduckgo ai chat', 'duckduckgo', 'ai chat', 'duck.ai'],


### PR DESCRIPTION
## Summary

Manual testing on meta.ai surfaced two issues:

- **Saves titled "today"/dates**: the generic `activeSidebarLink` strategy matched Meta's sidebar **date group header** (`[aria-current]` = "Today"), not the conversation. Meta now has dedicated strategies based on the real DOM: the active sidebar conversation link (`a[data-sidebar="menu-button"][data-active="true"] .truncate`), then the header title button (`header button[data-slot="button"] span.truncate`, filtered against generic labels since other header buttons share that markup), then the filtered document title and first user message.
- **`#` autocompletion mangled**: Meta's Lexical composer collapses the newlines of the inline multi-line suggestion injection and duplicates `#` characters. Meta joins Perplexity/Baidu on the `forceClear` path: exact `#name + space` injects after clearing the field; ambiguous prefixes pass the space through untouched.

## Testing

- `npx jest`: 265/265 green (new: active sidebar link with a decoy inactive entry, header button, "Today" rejection).
- `python build.py --yes` green.
- Verified by David on meta.ai (title extraction + trigger behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)