### PR TITLE
fix(af): dedicated title strategies for Pi, Qwen and Z.ai

### DIFF
--- a/extensions/ai-folders/site-config.js
+++ b/extensions/ai-folders/site-config.js
@@ -357,6 +357,47 @@ function extractAITitleLogic(siteKey, defaultFallback) {
       () => docTitle(fallbackIgnores),
       () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
     ];
+  } else if (siteKey === 'zai') {
+    fallbackIgnores = new Set(['z.ai', 'chat.z.ai', 'z.ai chat', 'new chat', '']);
+    strategies = [
+      // Sidebar entries are <button draggable="false"> elements (no links);
+      // the selected conversation carries data-selected="true", its title in
+      // a Tailwind <div class="… truncate …">
+      () => document.querySelector('button[data-selected="true"] .truncate')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
+  } else if (siteKey === 'qwen') {
+    // The title only exists in the sidebar "All chats" list (the header shows
+    // the model name and document.title stays "Qwen Studio").
+    fallbackIgnores = new Set(['qwen', 'qwen chat', 'qwen studio', 'new chat', '']);
+    strategies = [
+      // Sidebar entry whose link matches the current conversation path; the
+      // title text lives in .chat-item-drag-link-content-tip-text
+      () => {
+        const path = window.location.pathname;
+        if (path.length <= 1) return null;
+        const link = document.querySelector(`a[href*="${path}"]`);
+        return link?.querySelector('.chat-item-drag-link-content-tip-text')?.textContent?.trim() || null;
+      },
+      // Fallback: an active-marked chat item, whatever the exact marker class
+      () => document.querySelector('[class*="active"] .chat-item-drag-link-content-tip-text')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
+  } else if (siteKey === 'pi') {
+    fallbackIgnores = new Set(['pi', 'pi.ai', 'talk with pi', 'pi, your personal ai', '']);
+    strategies = [
+      // Active conversation entry in the sidebar: the selected row is a
+      // div[role="button"] carrying bg-fill-default (Tailwind), its title in
+      // <span class="text-body-s truncate …">
+      () => document.querySelector('div[role="button"].bg-fill-default span.truncate')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
   } else if (siteKey === 'baidu') {
     fallbackIgnores = new Set(['baidu', 'baidu chat', 'ai chat', '文心一言', '百度文心助手', '文心助手', 'new chat', '']);
     strategies = [
@@ -373,13 +414,10 @@ function extractAITitleLogic(siteKey, defaultFallback) {
     // list differs. Promote a site to its own branch above if it needs a
     // dedicated DOM strategy.
     const genericIgnores = {
-      zai: ['z.ai', 'chat.z.ai', 'new chat'],
-      qwen: ['qwen', 'qwen chat', 'new chat'],
       mistral: ['le chat', 'le chat - mistral ai', 'mistral ai', 'new chat'],
       poe: ['poe', 'new chat'],
       duckai: ['duckduckgo ai chat', 'duckduckgo', 'ai chat', 'duck.ai'],
       you: ['you.com', 'you', 'new chat'],
-      pi: ['pi', 'pi.ai', 'talk with pi', 'pi, your personal ai'],
       characterai: ['character.ai', 'characterai', 'c.ai', 'new chat'],
     }[siteKey];
     if (genericIgnores) {

--- a/tests/site-config.test.js
+++ b/tests/site-config.test.js
@@ -157,6 +157,35 @@ describe('extractAITitleLogic', () => {
     expect(extractAITitleLogic('meta', 'fallback')).toBe('Trip planning');
   });
 
+  test('zai: reads the selected sidebar conversation button', () => {
+    document.body.innerHTML =
+      '<button draggable="false"><div class="flex"><div class="text-left truncate leading-5">Autre</div></div></button>' +
+      '<button draggable="false" data-selected="true" class="w-full flex">' +
+      '  <div class="flex self-center flex-1"><div dir="auto" class="text-left self-center min-w-0 w-full truncate leading-5">Hello Greeting</div></div></button>';
+    expect(extractAITitleLogic('zai', 'fallback')).toBe('Hello Greeting');
+  });
+
+  test('qwen: reads the active sidebar chat item', () => {
+    document.body.innerHTML =
+      '<div class="chat-item"><div class="chat-item-drag-link-content-tip-text">Autre</div></div>' +
+      '<div class="chat-item chat-item-active"><div class="chat-item-drag-link-content">' +
+      '  <div class="chat-item-drag-link-content-tip-text chat-item-drag-link-content-tip">Hello Conversation</div></div></div>';
+    expect(extractAITitleLogic('qwen', 'fallback')).toBe('Hello Conversation');
+  });
+
+  test('qwen: ignores the generic "Qwen Studio" document title', () => {
+    document.title = 'Qwen Studio';
+    expect(extractAITitleLogic('qwen', 'New conversation')).toBe('New conversation');
+  });
+
+  test('pi: reads the active sidebar conversation entry', () => {
+    document.body.innerHTML =
+      '<div role="button" class="flex items-center"><span class="text-body-s truncate">Autre</span></div>' +
+      '<div role="button" class="flex items-center bg-fill-default text-text-secondary">' +
+      '  <div><span class="text-body-s truncate text-text-secondary">Greetings from Pi</span></div></div>';
+    expect(extractAITitleLogic('pi', 'fallback')).toBe('Greetings from Pi');
+  });
+
   test('baidu: reads the selected sidebar history item', () => {
     document.body.innerHTML =
       '<div class="chat-side-list-item">' +

--- a/tools/site-diagnostics/firefox/site-config.js
+++ b/tools/site-diagnostics/firefox/site-config.js
@@ -357,6 +357,47 @@ function extractAITitleLogic(siteKey, defaultFallback) {
       () => docTitle(fallbackIgnores),
       () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
     ];
+  } else if (siteKey === 'zai') {
+    fallbackIgnores = new Set(['z.ai', 'chat.z.ai', 'z.ai chat', 'new chat', '']);
+    strategies = [
+      // Sidebar entries are <button draggable="false"> elements (no links);
+      // the selected conversation carries data-selected="true", its title in
+      // a Tailwind <div class="… truncate …">
+      () => document.querySelector('button[data-selected="true"] .truncate')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
+  } else if (siteKey === 'qwen') {
+    // The title only exists in the sidebar "All chats" list (the header shows
+    // the model name and document.title stays "Qwen Studio").
+    fallbackIgnores = new Set(['qwen', 'qwen chat', 'qwen studio', 'new chat', '']);
+    strategies = [
+      // Sidebar entry whose link matches the current conversation path; the
+      // title text lives in .chat-item-drag-link-content-tip-text
+      () => {
+        const path = window.location.pathname;
+        if (path.length <= 1) return null;
+        const link = document.querySelector(`a[href*="${path}"]`);
+        return link?.querySelector('.chat-item-drag-link-content-tip-text')?.textContent?.trim() || null;
+      },
+      // Fallback: an active-marked chat item, whatever the exact marker class
+      () => document.querySelector('[class*="active"] .chat-item-drag-link-content-tip-text')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
+  } else if (siteKey === 'pi') {
+    fallbackIgnores = new Set(['pi', 'pi.ai', 'talk with pi', 'pi, your personal ai', '']);
+    strategies = [
+      // Active conversation entry in the sidebar: the selected row is a
+      // div[role="button"] carrying bg-fill-default (Tailwind), its title in
+      // <span class="text-body-s truncate …">
+      () => document.querySelector('div[role="button"].bg-fill-default span.truncate')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
   } else if (siteKey === 'baidu') {
     fallbackIgnores = new Set(['baidu', 'baidu chat', 'ai chat', '文心一言', '百度文心助手', '文心助手', 'new chat', '']);
     strategies = [
@@ -373,13 +414,10 @@ function extractAITitleLogic(siteKey, defaultFallback) {
     // list differs. Promote a site to its own branch above if it needs a
     // dedicated DOM strategy.
     const genericIgnores = {
-      zai: ['z.ai', 'chat.z.ai', 'new chat'],
-      qwen: ['qwen', 'qwen chat', 'new chat'],
       mistral: ['le chat', 'le chat - mistral ai', 'mistral ai', 'new chat'],
       poe: ['poe', 'new chat'],
       duckai: ['duckduckgo ai chat', 'duckduckgo', 'ai chat', 'duck.ai'],
       you: ['you.com', 'you', 'new chat'],
-      pi: ['pi', 'pi.ai', 'talk with pi', 'pi, your personal ai'],
       characterai: ['character.ai', 'characterai', 'c.ai', 'new chat'],
     }[siteKey];
     if (genericIgnores) {

--- a/tools/site-diagnostics/site-config.js
+++ b/tools/site-diagnostics/site-config.js
@@ -357,6 +357,47 @@ function extractAITitleLogic(siteKey, defaultFallback) {
       () => docTitle(fallbackIgnores),
       () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
     ];
+  } else if (siteKey === 'zai') {
+    fallbackIgnores = new Set(['z.ai', 'chat.z.ai', 'z.ai chat', 'new chat', '']);
+    strategies = [
+      // Sidebar entries are <button draggable="false"> elements (no links);
+      // the selected conversation carries data-selected="true", its title in
+      // a Tailwind <div class="… truncate …">
+      () => document.querySelector('button[data-selected="true"] .truncate')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
+  } else if (siteKey === 'qwen') {
+    // The title only exists in the sidebar "All chats" list (the header shows
+    // the model name and document.title stays "Qwen Studio").
+    fallbackIgnores = new Set(['qwen', 'qwen chat', 'qwen studio', 'new chat', '']);
+    strategies = [
+      // Sidebar entry whose link matches the current conversation path; the
+      // title text lives in .chat-item-drag-link-content-tip-text
+      () => {
+        const path = window.location.pathname;
+        if (path.length <= 1) return null;
+        const link = document.querySelector(`a[href*="${path}"]`);
+        return link?.querySelector('.chat-item-drag-link-content-tip-text')?.textContent?.trim() || null;
+      },
+      // Fallback: an active-marked chat item, whatever the exact marker class
+      () => document.querySelector('[class*="active"] .chat-item-drag-link-content-tip-text')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
+  } else if (siteKey === 'pi') {
+    fallbackIgnores = new Set(['pi', 'pi.ai', 'talk with pi', 'pi, your personal ai', '']);
+    strategies = [
+      // Active conversation entry in the sidebar: the selected row is a
+      // div[role="button"] carrying bg-fill-default (Tailwind), its title in
+      // <span class="text-body-s truncate …">
+      () => document.querySelector('div[role="button"].bg-fill-default span.truncate')?.textContent?.trim() || null,
+      activeSidebarLink,
+      () => docTitle(fallbackIgnores),
+      () => firstMsg('[data-message-author-role="user"], [class*="user"] [class*="message"]'),
+    ];
   } else if (siteKey === 'baidu') {
     fallbackIgnores = new Set(['baidu', 'baidu chat', 'ai chat', '文心一言', '百度文心助手', '文心助手', 'new chat', '']);
     strategies = [
@@ -373,13 +414,10 @@ function extractAITitleLogic(siteKey, defaultFallback) {
     // list differs. Promote a site to its own branch above if it needs a
     // dedicated DOM strategy.
     const genericIgnores = {
-      zai: ['z.ai', 'chat.z.ai', 'new chat'],
-      qwen: ['qwen', 'qwen chat', 'new chat'],
       mistral: ['le chat', 'le chat - mistral ai', 'mistral ai', 'new chat'],
       poe: ['poe', 'new chat'],
       duckai: ['duckduckgo ai chat', 'duckduckgo', 'ai chat', 'duck.ai'],
       you: ['you.com', 'you', 'new chat'],
-      pi: ['pi', 'pi.ai', 'talk with pi', 'pi, your personal ai'],
       characterai: ['character.ai', 'characterai', 'c.ai', 'new chat'],
     }[siteKey];
     if (genericIgnores) {


### PR DESCRIPTION
## Summary

Follow-up to #19, same pattern: the generic sidebar/title extraction chain failed on three sites; each gets a dedicated strategy based on the live DOM inspected by David:

- **Pi**: the selected sidebar row is `div[role="button"].bg-fill-default` (Tailwind marker), title in its `.truncate` span. Noted as more fragile than a semantic attribute — site-diagnostics will catch a theme refactor.
- **Qwen**: the title only exists in the sidebar "All chats" list (`.chat-item-drag-link-content-tip-text`) — matched via the link containing the current conversation path, then via an active-marked item; the permanent `document.title` ("Qwen Studio") joins the rejected generic titles.
- **Z.ai**: sidebar entries are `<button draggable="false">` elements (no links) — the selected one carries `data-selected="true"`, title in its `.truncate` div.

## Testing

- `npx jest`: 269/269 green — each new strategy exercised in jsdom with a decoy inactive sibling.
- `python build.py --yes` green.
- Verified by David on pi.ai, chat.qwen.ai and chat.z.ai (Pi and Z.ai confirmed working; Qwen strategy built from the same inspected DOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)