### PR TITLE
harden: gate stored URLs at tab/bookmark sinks + reject unsafe import keys

### DIFF
--- a/src/folders.js
+++ b/src/folders.js
@@ -530,8 +530,11 @@ async function openFolderInTabGroup(folderName, chats) {
   try {
     const tabIds = [];
 
-    // 1. Create all tabs in background
+    // 1. Create all tabs in background. Gate on isSafeUrl (defence-in-depth): the
+    //    import path already rejects unsafe URLs, but legacy/corrupt storage must
+    //    never reach chrome.tabs.create with a javascript:/data: URL.
     for (const chat of chats) {
+      if (!isSafeUrl(chat.url)) continue;
       const tab = await chrome.tabs.create({ url: chat.url, active: false });
       tabIds.push(tab.id);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -336,6 +336,9 @@ async function syncToBookmarksTree(folders, pinnedFolders = [], sortPref = 'date
 
       for (let j = 0; j < chats.length; j++) {
         const chat = chats[j];
+        // Defence-in-depth: never mirror an unsafe URL into the bookmark tree,
+        // even if legacy/corrupt storage carries one (import already gates on this).
+        if (!isSafeUrl(chat.url)) continue;
         await new Promise(r => chrome.bookmarks.create({
           parentId: folderNode.id,
           title: chat.title,
@@ -405,6 +408,12 @@ function mergeImportData(importedData) {
       let currentPrompts = data.prompts || {};
 
       const isPlainObject = (v) => v && typeof v === 'object' && !Array.isArray(v);
+      // JSON.parse creates OWN "__proto__"/"constructor"/"prototype" properties, so
+      // Object.entries surfaces them here. Accessing currentFolders["__proto__"]
+      // resolves to Object.prototype (and ["constructor"] to the Object function),
+      // whose `.some`/`.push` don't exist — a single such key would throw and abort
+      // the whole import. Skip them: robustness, not prototype-pollution (guarded).
+      const isUnsafeKey = (k) => k === '__proto__' || k === 'constructor' || k === 'prototype';
 
       // --- BACKWARD COMPATIBILITY MANAGEMENT ---
       // Current format wraps content in { folders, pinnedFolders, prompts };
@@ -429,7 +438,7 @@ function mergeImportData(importedData) {
       // 1. Merge folders and conversations. Skip entries whose value isn't an
       //    array of chats, and validate each chat's shape before storing it.
       for (const [folderName, chats] of Object.entries(foldersToImport)) {
-        if (typeof folderName !== 'string' || !Array.isArray(chats)) continue;
+        if (typeof folderName !== 'string' || isUnsafeKey(folderName) || !Array.isArray(chats)) continue;
         if (!currentFolders[folderName]) currentFolders[folderName] = [];
         chats.forEach(importedChat => {
           if (isPlainObject(importedChat)
@@ -445,14 +454,14 @@ function mergeImportData(importedData) {
 
       // 2. Merge pins (without creating duplicates)
       pinsToImport.forEach(pin => {
-        if (typeof pin === 'string' && !currentPinned.includes(pin) && currentFolders[pin]) {
+        if (typeof pin === 'string' && !isUnsafeKey(pin) && !currentPinned.includes(pin) && currentFolders[pin]) {
           currentPinned.push(pin);
         }
       });
 
       // 3. Merge prompts
       for (const [promptTitle, promptData] of Object.entries(promptsToImport)) {
-        if (typeof promptTitle !== 'string') continue;
+        if (typeof promptTitle !== 'string' || isUnsafeKey(promptTitle)) continue;
         const normalized = normalizePromptData(promptData);
         if (!normalized) continue; // skip malformed prompt entries
         if (!currentPrompts[promptTitle]) {

--- a/tests/folders.test.js
+++ b/tests/folders.test.js
@@ -312,6 +312,27 @@ describe('openFolderInTabGroup', () => {
     expect(chrome.tabs.create).not.toHaveBeenCalled();
   });
 
+  test('skips unsafe stored URLs, opening only the safe ones', async () => {
+    // Override the permissive default mock with the real http(s)-only check.
+    global.isSafeUrl = jest.fn((url) => {
+      try { return /^https?:$/.test(new URL(url).protocol); } catch { return false; }
+    });
+    const chats = [
+      { url: 'https://a/1' },
+      { url: 'javascript:alert(1)' }, // legacy/corrupt storage — must never open
+      { url: 'https://a/2' },
+    ];
+
+    await openFolderInTabGroup('Mixed', chats);
+
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(2);
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: 'https://a/1', active: false });
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: 'https://a/2', active: false });
+    expect(chrome.tabs.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'javascript:alert(1)' })
+    );
+  });
+
   test('aborts before opening tabs when the >10-tab confirm is declined', async () => {
     global.window.showCustomModal.mockResolvedValue(false);
     const chats = Array.from({ length: 11 }, (_, i) => ({ url: `https://a/${i}` }));

--- a/tests/utils-helpers.test.js
+++ b/tests/utils-helpers.test.js
@@ -203,6 +203,22 @@ describe('syncToBookmarksTree', () => {
     expect(folderCreate.title).toBe('🚀 Launch');
   });
 
+  test('does not mirror an unsafe stored URL into the bookmark tree', async () => {
+    const folders = {
+      Dev: [
+        { title: 'safe', url: 'https://a/ok', timestamp: 2 },
+        { title: 'evil', url: 'javascript:alert(1)', timestamp: 1 },
+      ],
+    };
+
+    await syncToBookmarksTree(folders, [], 'dateDesc');
+
+    const chatCreates = chrome.bookmarks.create.mock.calls
+      .map((c) => c[0])
+      .filter((o) => o.url);
+    expect(chatCreates.map((o) => o.url)).toEqual(['https://a/ok']);
+  });
+
   test('a re-entrant call while a sync is in flight is ignored', async () => {
     const folders = { A: [{ title: 'c', url: 'https://a/y', timestamp: 1 }] };
     const first = syncToBookmarksTree(folders, [], 'dateDesc'); // holds the lock

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -511,6 +511,44 @@ describe('mergeImportData', () => {
     expect(folders.Good).toHaveLength(1);
   });
 
+  // JSON.parse creates OWN "__proto__"/"constructor" properties (unlike a JS object
+  // literal, which would set the prototype). This mirrors what the real import does
+  // when reading a hand-crafted/corrupt backup file. Without the isUnsafeKey guard,
+  // currentFolders["__proto__"] resolves to Object.prototype and `.some` throws,
+  // aborting the entire import.
+  test('skips a __proto__ folder key without throwing, keeping valid folders', async () => {
+    const importedData = JSON.parse(
+      '{"folders":{"__proto__":[{"title":"X","url":"https://gemini.google.com/app/x","timestamp":1}],' +
+      '"Good":[{"title":"C","url":"https://gemini.google.com/app/g","timestamp":2}]}}'
+    );
+    await expect(mergeImportData(importedData)).resolves.toBeUndefined();
+    const folders = savedFolders();
+    expect(folders.Good).toHaveLength(1);
+    expect(Object.prototype.hasOwnProperty.call(folders, '__proto__')).toBe(false);
+    // Prototype chain must be untouched (no pollution).
+    expect(({}).some).toBeUndefined();
+  });
+
+  test('skips a constructor folder key without throwing', async () => {
+    const importedData = JSON.parse(
+      '{"folders":{"constructor":[{"title":"X","url":"https://gemini.google.com/app/x","timestamp":1}],' +
+      '"Good":[{"title":"C","url":"https://gemini.google.com/app/g","timestamp":2}]}}'
+    );
+    await expect(mergeImportData(importedData)).resolves.toBeUndefined();
+    expect(savedFolders().Good).toHaveLength(1);
+  });
+
+  test('skips __proto__/constructor prompt keys without throwing', async () => {
+    const importedData = JSON.parse(
+      '{"folders":{},"prompts":{"__proto__":{"text":"bad","timestamp":1},' +
+      '"constructor":{"text":"bad2","timestamp":1},"Good":{"text":"ok","timestamp":2}}}'
+    );
+    await expect(mergeImportData(importedData)).resolves.toBeUndefined();
+    const prompts = savedPrompts();
+    expect(prompts.Good.text).toBe('ok');
+    expect(Object.prototype.hasOwnProperty.call(prompts, '__proto__')).toBe(false);
+  });
+
   test('skips malformed prompt entries, keeping valid ones', async () => {
     const importedData = {
       folders: {},


### PR DESCRIPTION
Two low-severity, defence-in-depth fixes surfaced by an external audit. Both changes live in shared `src/`, so **Gemini Folders and AI Folders both get them** from a single PR.

## 1. Stored URL hardening (audit point 1)

The display path already gates `chat.url` through `isSafeUrl` (`folders.js` link render), but two other sinks trusted it directly:

- **Open folder in a tab group** — `chrome.tabs.create({ url: chat.url })` (`src/folders.js`)
- **Bookmark mirror / mobile sync** — `chrome.bookmarks.create({ url: chat.url })` (`src/utils.js`)

Import validates URLs on entry (`mergeImportData` rejects non-`isSafeUrl`), so in normal use nothing unsafe ever reaches storage — this is purely defence-in-depth for legacy/corrupt storage. Both sinks now skip any chat whose `url` isn't `isSafeUrl`.

`isSafeUrl` allows `http`/`https`, i.e. every real conversation URL — cross-extension imports (AF links into GF) are unaffected.

## 2. Import special-key robustness (audit point 3)

`JSON.parse` creates **own** `"__proto__"` / `"constructor"` / `"prototype"` properties, which `Object.entries` then surfaces in the merge loop. `currentFolders["__proto__"]` resolves to `Object.prototype` (and `["constructor"]` to the `Object` function), whose `.some`/`.push` don't exist — so a single such key **threw and aborted the entire import** (the `currentFolders[folderName].some is not a function` the audit reproduced).

This is **not** prototype pollution — the guarded access already prevented that — it's a robustness bug: one poisoned key from a hand-crafted/corrupt backup killed the whole import. Those keys are now skipped in the folders, pins, and prompts merge loops.

## Not changed

The popup "new conversation" buttons (`chrome.tabs.create` with `site.newConvUrl` / configured Gem link / configured local-LLM URL) use constants or user-configured settings, not bulk-imported `chat.url` — a different trust model, out of scope for this audit point.

Audit point 2 (`#`-trigger replacing editor content) was assessed as a non-realistic scenario: injection only fires when the field is just the `#`-line or the extension's own transient suggestion block sits directly below it, so normal prose starting with `#` passes through untouched. No change.

## Testing

- `npx jest` — 274 passing (5 new: unsafe URL skipped at both sinks; `__proto__`/`constructor` keys skipped in folders and prompts without throwing and without polluting the prototype chain).
- `python build.py --yes` — both extensions build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)