### PR TITLE
feat(store-publisher): sync AMO listing name from extName

### DIFF
--- a/tools/store-publisher/README.md
+++ b/tools/store-publisher/README.md
@@ -86,14 +86,16 @@ python amo_publish.py --item gemini-folders --texts --images          # dry-run
 python amo_publish.py --item gemini-folders --texts --images --apply  # write
 ```
 
-- `--texts` PATCHes the listing description **and summary** for every locale
-  AMO supports, in a single request: the description from
+- `--texts` PATCHes the listing description, summary **and name** for every
+  locale AMO supports, in a single request: the description from
   `dist/<slug>/marketing_firefox/Promo<XX>.txt`, the summary from the
-  extension's own `extDesc` string (`dist/<slug>/firefox/_locales/…`, so the
-  two always stay in sync — the script validates AMO's 250-char summary cap).
-  AMO production only enables 42 languages: 28 of our 43 map (see the `amo`
-  column in `lib/locales.js`); the other 15 are skipped with a log line.
-  Locales omitted from the PATCH are left untouched on AMO.
+  extension's own `extDesc` string and the name from its `extName` string
+  (`dist/<slug>/firefox/_locales/…`, so the listing always stays in sync — the
+  script validates AMO's 250-char summary and 50-char name caps). The **name is
+  sent only for locales where it actually changed** vs the live listing (an
+  unchanged title isn't rewritten). AMO production only enables 42 languages:
+  28 of our 43 map (see the `amo` column in `lib/locales.js`); the other 15 are
+  skipped with a log line. Locales omitted from the PATCH are left untouched on AMO.
 - `--images` deletes the listing previews and uploads `Promo_1..5_en.png`
   with explicit positions. AMO previews are **not** localized — one set per
   listing — so this runs once, not per locale.

--- a/tools/store-publisher/amo_publish.py
+++ b/tools/store-publisher/amo_publish.py
@@ -48,6 +48,7 @@ TOOL_DIR = Path(__file__).resolve().parent
 STATE_FILE = TOOL_DIR / ".amo-previews-state.json"  # gitignored
 SCREENSHOTS_PER_LISTING = 5
 AMO_SUMMARY_MAX = 250   # AMO rejects summaries above this length
+AMO_NAME_MAX = 50       # AMO rejects add-on names above this length
 REQUEST_GAP_S = 1.0     # initial delay before each write request (grows on throttle)
 MAX_PACE_S = 30.0       # cap for the adaptive pacing delay
 AUTO_RETRY_CAP_S = 180  # longest we'll auto-sleep on a single throttle before retrying
@@ -205,17 +206,53 @@ def build_summaries(locales_dir, locales):
     return out
 
 
-def update_texts(creds, guid, descriptions, summaries, apply):
+def build_names(locales_dir, locales):
+    """Reads every supported locale's extName from the built Firefox _locales.
+    Returns {amo_code: text} — the AMO listing name mirrors the extension's own
+    name string (manifest `name` = extName), so the store title tracks it."""
+    if not locales_dir.is_dir():
+        sys.exit(f"Locales dir not found: {locales_dir} — run `python build.py` first.")
+    out = {}
+    for loc in locales:
+        if not loc["amo"]:
+            continue
+        path = locales_dir / loc["internal"] / "messages.json"
+        msg = json.loads(path.read_text(encoding="utf-8-sig")).get("extName", {}).get("message", "").strip()
+        if not msg:
+            sys.exit(f"extName missing/empty in {path}")
+        if len(msg) > AMO_NAME_MAX:
+            sys.exit(f"extName for {loc['internal']} is {len(msg)} chars (AMO name max {AMO_NAME_MAX}): {msg[:80]}…")
+        out[loc["amo"]] = msg
+    print(f"Names: {len(out)} locales from extName")
+    return out
+
+
+def changed_only(new, current):
+    """Keeps only entries whose value differs from the live listing, so an
+    unchanged name/field isn't rewritten (AMO throttles writes and every edit
+    goes live immediately). `current` is the addon's localized field (or None)."""
+    cur = current if isinstance(current, dict) else {}
+    return {code: text for code, text in new.items() if cur.get(code) != text}
+
+
+def update_texts(creds, guid, descriptions, summaries, names, apply):
     if not apply:
         for code, text in sorted(descriptions.items()):
             print(f"  would send description[{code}]: {len(text)} chars"
                   + (f", summary: {len(summaries[code])} chars" if code in summaries else ""))
+        for code, name in sorted(names.items()):
+            print(f"  would send name[{code}]: {name!r}")
+        if not names:
+            print("  name: no changes vs the live listing — nothing to send")
         return
-    # One PATCH carries every locale and both fields; omitted locales stay
-    # untouched on AMO.
-    api_request(creds, "PATCH", f"/addons/addon/{guid}/",
-                json_body={"description": descriptions, "summary": summaries})
-    print(f"  description + summary updated for {len(descriptions)} locales ✓")
+    # One PATCH carries every locale and every field; omitted locales/fields stay
+    # untouched on AMO. `name` is sent only for locales that actually changed.
+    body = {"description": descriptions, "summary": summaries}
+    if names:
+        body["name"] = names
+    api_request(creds, "PATCH", f"/addons/addon/{guid}/", json_body=body)
+    print(f"  description + summary updated for {len(descriptions)} locales"
+          + (f"; name updated for {len(names)} locale(s) ✓" if names else "; name unchanged ✓"))
 
 
 def file_fingerprints(files):
@@ -337,7 +374,8 @@ def main():
     if args.texts:
         descriptions = build_descriptions(marketing_dir, locales)
         summaries = build_summaries(locales_dir, locales)
-        update_texts(creds, guid, descriptions, summaries, args.apply)
+        names = changed_only(build_names(locales_dir, locales), addon.get("name"))
+        update_texts(creds, guid, descriptions, summaries, names, args.apply)
     if args.images:
         update_images(creds, guid, addon, marketing_dir, locales, args.apply, args.force_images)
 


### PR DESCRIPTION
Follow-up to the SEO-title release (#26): teach `amo_publish.py --texts` to also push the extension **name** to the AMO listing, so the store title tracks `extName` the same way the summary already tracks `extDesc`.

## Change
- New `build_names()` reads each supported locale's `extName` from the built Firefox `_locales` (mirrors `build_summaries()` for `extDesc`), validating AMO's **50-char name cap**.
- `update_texts()` adds `name` to the single PATCH — **only for locales whose title actually changed** vs the live listing (`changed_only()`), so an unchanged name is never rewritten (AMO throttles writes and every edit goes live immediately).
- README updated.

## Verification
- `python -m py_compile` clean; functional check against `dist/ai-folders/firefox/_locales`: 28 AMO locales resolved, max name length 47 ≤ 50, and `changed_only` correctly sends nothing when the live name matches, everything when it differs, and only the delta otherwise.
- `npx jest` — 278 passing (JS suite unaffected; this is maintainer Python tooling, not shipped).
- Dry-run still the default; `--apply` required to write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)