### PR TITLE
fix(welcome): centre the CTA, use Chrome's own glyphs, match the popup button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,15 @@ a feature tour. Baselines to measure against are in §11.
   user-configured local LLM — are left out of a row that says "open a conversation
   on one of these". Step 3 is a CSS replica of the popup's own add-conversation
   button, localized, so it is recognizable once the popup opens.
+- **The replica copies the popup button's *computed* values, not its source.**
+  `popup.css` declares a `.main-btn` block inside its `prefers-color-scheme: dark`
+  media query (translucent blue, 1px border, blue glow) that the plain `.main-btn`
+  rule further down overrides at equal specificity — so **none of that dark block
+  ever applies**, and transcribing it would have produced a button no user sees.
+  Read the values out of the browser if you touch this. (The dead block is a real
+  popup.css wart; cleaning it belongs with the §8 CSS cleanup, not here.)
+  A test pins the replica to the popup's dark `--accent-color` / `--shadow-sm` so a
+  restyle of the popup fails loudly instead of drifting.
 - **Step 3's text quotes the popup's Save button through a `{b}` placeholder**, which
   `welcome.js` fills with this locale's `saveBtn`. Never hardcode the button name
   into a translation: the substitution is what stops the instruction from naming a

--- a/src/welcome.css
+++ b/src/welcome.css
@@ -162,25 +162,35 @@ img { max-width: 100%; display: block; }
 }
 .site-row.site-row-single img { width: 44px; height: 44px; border-radius: 11px; }
 
-/* Replica of the popup's add-conversation button (.main-btn in popup.css). */
+/* Replica of the popup's add-conversation button. It has to be indistinguishable
+   from the real one, so these are the values the real #toggleAddPanelBtn actually
+   *computes to* in dark mode — read out of the browser, not transcribed from the
+   source. That distinction matters: popup.css declares a `.main-btn` block inside
+   its `prefers-color-scheme: dark` media query (translucent blue, 1px border, blue
+   glow), but the plain `.main-btn` rule further down the file overrides every one
+   of those properties at equal specificity, so none of it ever applies. Copying the
+   source would have produced a button the user never sees.
+   The font is pinned too: popup.css sets its family on `body` and the button
+   inherits it, so this page's display font must not leak in. */
 .popup-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   height: 32px;
-  padding: 0 14px;
+  padding: 0 10px;
+  border: none;
   border-radius: 8px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
   color: #fff;
-  background: rgba(100, 148, 240, 0.80);
-  border: 1px solid rgba(138, 180, 248, 0.35);
-  box-shadow: 0 2px 12px rgba(80, 120, 255, 0.20);
+  background: #8ab4f8;                    /* --accent-color, dark scheme */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4); /* --shadow-sm, dark scheme */
 }
 
 /* --- Call to action: the site's .btn / .btn-primary --- */
-.cta-row { margin-top: 40px; }
+.cta-row { margin-top: 40px; text-align: center; }
 .btn {
   display: inline-flex;
   align-items: center;

--- a/src/welcome.html
+++ b/src/welcome.html
@@ -39,20 +39,21 @@
           <p class="step-body" id="wPinBody"></p>
         </div>
         <div class="step-art">
-          <!-- Chrome's toolbar button is Material "extension"; the menu entry next
-               to it is Material "push_pin". Showing the two real glyphs, in order,
-               is the whole instruction. -->
+          <!-- The two glyphs Chrome itself uses: Material Symbols "extension" (the
+               toolbar button) then "keep" (the pin in the menu it opens). Showing
+               them in order is the whole instruction. Both are the 24dp wght400
+               outlines, so their 0 -960 960 960 viewBox is not a typo. -->
           <span class="glyph">
-            <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-              <path d="M20.5 11H19V7c0-1.1-.9-2-2-2h-4V3.5C13 2.12 11.88 1 10.5 1S8 2.12 8 3.5V5H4c-1.1 0-1.99.9-1.99 2v3.8H3.5c1.49 0 2.7 1.21 2.7 2.7s-1.21 2.7-2.7 2.7H2V19c0 1.1.9 2 2 2h3.8v-1.5c0-1.49 1.21-2.7 2.7-2.7s2.7 1.21 2.7 2.7V21H17c1.1 0 2-.9 2-2v-4h1.5c1.38 0 2.5-1.12 2.5-2.5S21.88 11 20.5 11z"/>
+            <svg viewBox="0 -960 960 960" role="img" aria-hidden="true">
+              <path d="M200-200h520v-184l45-22q16-8 25.5-22t9.5-32q0-17-9.5-31.5T765-514l-45-21v-185H528l-10-68q-3-22-19.5-37T460-840q-23 0-39.5 15T401-788l-10 68H200v86q56 21 88 68t32 106q0 60-32 107t-88 68v85Zm0 80q-34 0-57-23t-23-57v-152q48 0 84-30.5t36-77.5q0-46-36-76t-84-32v-152q0-33 23.5-56.5T200-800h122q7-51 46-85.5t92-34.5q52 0 91 34.5t47 85.5h122q33 0 56.5 23.5T800-720v134q36 18 58 52t22 74q0 41-22 75t-58 51v134q0 34-23.5 57T720-120H200Zm300-340Z"/>
             </svg>
           </span>
           <span class="glyph-sep" aria-hidden="true">
             <svg viewBox="0 0 24 24"><path d="M9 5l7 7-7 7" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </span>
           <span class="glyph glyph-accent">
-            <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
-              <path d="M16 9V4h1a1 1 0 0 0 0-2H7a1 1 0 0 0 0 2h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z"/>
+            <svg viewBox="0 -960 960 960" role="img" aria-hidden="true">
+              <path d="m640-480 80 80v80H520v240l-40 40-40-40v-240H240v-80l80-80v-280h-40v-80h400v80h-40v280Zm-286 80h252l-46-46v-314H400v314l-46 46Zm126 0Z"/>
             </svg>
           </span>
         </div>

--- a/tests/welcome.test.js
+++ b/tests/welcome.test.js
@@ -138,6 +138,29 @@ describe('welcome page rendering', () => {
     }
   });
 
+  // The step-3 button is a hand-copied replica of the popup's own, so it can drift
+  // the day someone restyles the popup. jsdom has no CSS engine to compare against,
+  // but pinning the two values the replica hardcodes is enough to catch it: if the
+  // popup's dark accent or card shadow changes, this fails and points here.
+  test('the add-button replica still matches the popup accent it copies', () => {
+    const popupCss = fs.readFileSync(path.join(ROOT, 'src/popup.css'), 'utf8');
+    const welcomeCss = fs.readFileSync(path.join(ROOT, 'src/welcome.css'), 'utf8');
+    const dark = popupCss.slice(popupCss.indexOf('@media (prefers-color-scheme: dark)'));
+    // Space after a comma is free variation in CSS but not in a string compare.
+    const tidy = (s) => s.replace(/\s+/g, ' ').replace(/,\s/g, ',').trim().toLowerCase();
+    const tokenOf = (name) => tidy(dark.match(new RegExp(`--${name}:\\s*([^;]+);`))[1]);
+
+    // Bounded to the rule body, so a later rule's background cannot stand in for it.
+    const start = welcomeCss.indexOf('.popup-btn {');
+    const replica = welcomeCss.slice(start, welcomeCss.indexOf('}', start));
+    expect(tidy(replica.match(/background:\s*([^;]+);/)[1])).toBe(tokenOf('accent-color'));
+    expect(tidy(replica.match(/box-shadow:\s*([^;]+);/)[1])).toBe(tokenOf('shadow-sm'));
+    // The popup sets its own family on body and the button inherits it; the page's
+    // display font must not leak into the replica.
+    expect(replica).toContain("font-family: 'Inter'");
+    expect(replica).toContain('font-weight: 600');
+  });
+
   test('the page never reaches the network or writes storage', () => {
     // It opens unprompted on install, so it must stay inert: no telemetry, no
     // "seen the welcome page" flag, nothing that could look like a phone-home.


### PR DESCRIPTION
Feedback pass on #35.

- **CTA centred.**
- **Step 1 uses the Material Symbols outlines you supplied** — `extension` for Chrome's toolbar button, `keep` for the pin. Their `0 -960 960 960` viewBox is the Material Symbols convention, worth knowing before someone "fixes" it.
- **The add-conversation replica now really matches the popup's button.**

## On that last one

It was off on three counts: the font (the page's display face instead of the popup's Inter stack), weight 500 instead of 600, and a noticeably darker blue.

The colour was not a transcription slip. `popup.css` declares a `.main-btn` block **inside** its `prefers-color-scheme: dark` media query — translucent blue, 1px border, blue glow — and the plain `.main-btn` rule further down the file overrides every one of those properties at equal specificity. A media query adds no specificity, so **none of that dark block ever applies**. Copying the source gave a button no user has ever seen.

The replica now carries what the real button *computes to* in dark mode — `#8ab4f8`, `--shadow-sm`, no border, Inter 600 — read out of the browser rather than off the page. Verified with `getComputedStyle` against the real `#toggleAddPanelBtn`: identical on all twelve properties, and the same width to 0.01px (197.55px).

**Worth your attention separately:** that dead dark-mode `.main-btn` block is a real `popup.css` wart. Fixing it would change how the popup's own button renders, so it belongs with the §8 CSS cleanup rather than in this PR — flagging it rather than silently touching the popup.

A test pins the replica to the popup's dark `--accent-color` / `--shadow-sm`, so restyling the popup fails loudly instead of letting the copy drift.

## Verification

536 tests green; `python build.py --yes` clean; page re-rendered for AI Folders and Gemini Folders, and the step-1 glyphs checked at 4× zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)