### PR TITLE
fix(welcome): use Firefox's own puzzle glyph on Firefox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Working guide for this repository
+# AGENTS.md — Working guide for this repository
 
 This file is the onboarding brief for an agent (or contributor) picking up a task
 here. It captures the project structure, the build/test/release procedures, the
@@ -13,7 +13,7 @@ Two Manifest V3 browser extensions (Chrome **and** Firefox) that organize AI
 conversations into folders and provide a reusable prompt library:
 
 - **Gemini Folders (GF)** — Google Gemini only. Current version **4.5.4**.
-- **AI Folders (AF)** — 18 web platforms (Gemini, Claude, ChatGPT, Copilot,
+- **AI Folders (AF)** — 18 web platforms (Gemini, Codex, ChatGPT, Copilot,
   DeepSeek, Grok, Perplexity, Baidu, Z.ai, Kimi, Qwen, Meta AI, Mistral, Poe,
   Duck.ai, You.com, Pi, Character.AI) **+ a user-configured local LLM**.
   Current version **1.6.2**. The popup's per-site "new conversation" buttons
@@ -146,8 +146,8 @@ gh pr checks --watch                       # wait for the 3 checks to go green
 gh pr merge --squash --admin --delete-branch
 git checkout main && git pull --ff-only
 ```
-- End commit messages with: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
-- End PR bodies with the Claude Code footer.
+- End commit messages with: `Co-Authored-By: Codex Opus 4.8 <noreply@anthropic.com>`
+- End PR bodies with the Codex footer.
 - The repo is `dlamarre-dev/AI-Gemini-Folders`; `gh` is authenticated.
 
 ---
@@ -175,7 +175,7 @@ git checkout main && git pull --ff-only
   extensions. Prefer **reusing existing keys** wherever possible.
 - **Store text (`Marketing/`)** must never contain comma-separated brand lists
   (Chrome Web Store keyword-spam rejection, hit 3× historically). Prose such as
-  "platforms such as Claude, ChatGPT and Gemini" is fine; bare keyword lists are not.
+  "platforms such as Codex, ChatGPT and Gemini" is fine; bare keyword lists are not.
 - **~2px transparent gap on the right of the popup** at fractional Windows DPI
   (125/150%): a device-pixel rounding artifact, **outside the document → not
   fixable in CSS**. Disappears at 100% scaling. Accepted as-is. **Never** retry
@@ -320,13 +320,7 @@ the user actually sees. Five locales (et, hi, lt, ms, sw) have that file without
 key, so Firefox falls back to en-US there — quoting the English label is correct for
 them, not a gap. Serbian is the Latin transliteration of Firefox's Cyrillic label
 (§6 / `tests/serbian-latin.test.js`). The step-1 artwork stays puzzle → pin in both
-browsers — the pin is the *outcome*, which is what the step title promises — but the
-**puzzle glyph itself is per-browser**: `.ico-chrome` (Material Symbols `extension`,
-filled) and `.ico-firefox` (Firefox's outline puzzle, stroked) both ship in the HTML
-and `pickExtensionsGlyph()` removes the one that does not apply. Exactly one must
-survive or they stack inside the same 38px tile. The outline needs `fill: none` **and**
-its `stroke-width` declared in `welcome.css`: presentation attributes on the markup
-lose to any CSS rule, so `.glyph svg { fill }` would otherwise flood the shape.
+browsers: the pin is the *outcome*, which is what the step title promises.
 
 - **`src/welcome.html` + `welcome.js` + `welcome.css` are shared** by both
   extensions. Every string comes from `chrome.i18n`, so the Gemini-vs-18-sites

--- a/src/welcome.css
+++ b/src/welcome.css
@@ -144,6 +144,20 @@ img { max-width: 100%; display: block; }
   border: 1px solid var(--card-border);
 }
 .glyph svg { width: 22px; height: 22px; fill: var(--muted); }
+/* Firefox's extensions glyph is an outline, not a solid. Its stroke width has to
+   be declared here and not left as a presentation attribute: any CSS rule beats a
+   presentation attribute, so `fill` above would otherwise flood the shape. Nudged
+   a little larger than the filled Material glyph so the two read at the same
+   visual weight in the 38px tile. */
+.glyph svg.ico-firefox {
+  width: 24px;
+  height: 24px;
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 34;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
 .glyph-accent { background: rgba(138, 109, 240, 0.16); border-color: rgba(138, 109, 240, 0.42); }
 .glyph-accent svg { fill: var(--violet-2); }
 .glyph-sep { color: var(--faint); flex: none; }

--- a/src/welcome.html
+++ b/src/welcome.html
@@ -39,13 +39,20 @@
           <p class="step-body" id="wPinBody"></p>
         </div>
         <div class="step-art">
-          <!-- The two glyphs Chrome itself uses: Material Symbols "extension" (the
-               toolbar button) then "keep" (the pin in the menu it opens). Showing
-               them in order is the whole instruction. Both are the 24dp wght400
-               outlines, so their 0 -960 960 960 viewBox is not a typo. -->
+          <!-- The glyphs the browser itself uses, in order — that pairing is the
+               whole instruction. The extensions button differs per browser, so both
+               are here and welcome.js drops the one that does not apply:
+                 .ico-chrome  Material Symbols "extension", 24dp wght400 (hence the
+                              0 -960 960 960 viewBox — not a typo)
+                 .ico-firefox the outline puzzle Firefox shows for its Extensions
+                              panel; stroked rather than filled, styled in welcome.css
+               The pin beside them is Material Symbols "keep" and is shared. -->
           <span class="glyph">
-            <svg viewBox="0 -960 960 960" role="img" aria-hidden="true">
+            <svg class="ico-chrome" viewBox="0 -960 960 960" role="img" aria-hidden="true">
               <path d="M200-200h520v-184l45-22q16-8 25.5-22t9.5-32q0-17-9.5-31.5T765-514l-45-21v-185H528l-10-68q-3-22-19.5-37T460-840q-23 0-39.5 15T401-788l-10 68H200v86q56 21 88 68t32 106q0 60-32 107t-88 68v85Zm0 80q-34 0-57-23t-23-57v-152q48 0 84-30.5t36-77.5q0-46-36-76t-84-32v-152q0-33 23.5-56.5T200-800h122q7-51 46-85.5t92-34.5q52 0 91 34.5t47 85.5h122q33 0 56.5 23.5T800-720v134q36 18 58 52t22 74q0 41-22 75t-58 51v134q0 34-23.5 57T720-120H200Zm300-340Z"/>
+            </svg>
+            <svg class="ico-firefox" viewBox="0 0 512 512" role="img" aria-hidden="true">
+              <path d="M413.66,246.1H386a2,2,0,0,1-2-2V166.86A38.86,38.86,0,0,0,345.14,128H267.9a2,2,0,0,1-2-2V98.34c0-27.14-21.5-49.86-48.64-50.33a49.53,49.53,0,0,0-50.4,49.51V126a2,2,0,0,1-2,2H87.62A39.74,39.74,0,0,0,48,167.62V238a2,2,0,0,0,2,2H76.91c29.37,0,53.68,25.48,54.09,54.85.42,29.87-23.51,57.15-53.29,57.15H50a2,2,0,0,0-2,2v70.38A39.74,39.74,0,0,0,87.62,464H158a2,2,0,0,0,2-2V441.07c0-30.28,24.75-56.35,55-57.06,30.1-.7,57,20.31,57,50.28V462a2,2,0,0,0,2,2h71.14A38.86,38.86,0,0,0,384,425.14v-78a2,2,0,0,1,2-2h28.48c27.63,0,49.52-22.67,49.52-50.4S440.8,246.1,413.66,246.1Z"/>
             </svg>
           </span>
           <span class="glyph-sep" aria-hidden="true">

--- a/src/welcome.js
+++ b/src/welcome.js
@@ -100,6 +100,13 @@ function buildSiteRow() {
   }
 }
 
+// The two browsers draw their extensions button differently, so the page ships both
+// glyphs and keeps only the one that matches — same branch as the pin wording.
+function pickExtensionsGlyph() {
+  const drop = document.querySelector(IS_FIREFOX ? '.ico-chrome' : '.ico-firefox');
+  if (drop) drop.remove();
+}
+
 function buildAddButton() {
   const btn = document.getElementById('wAddBtn');
   // Matches how the popup composes the same label (popup-core.js).
@@ -108,6 +115,7 @@ function buildAddButton() {
 
 document.addEventListener('DOMContentLoaded', () => {
   applyI18n();
+  pickExtensionsGlyph();
   buildSiteRow();
   buildAddButton();
   document.getElementById('wCta').addEventListener('click', () => {

--- a/tests/welcome.test.js
+++ b/tests/welcome.test.js
@@ -42,8 +42,17 @@ function load({ lang = 'en', missingI18n = false, sites, messages, ua = REAL_UA 
   document.body.removeAttribute('dir');
   // Only the <body> content — jsdom ignores <head> in innerHTML anyway.
   document.body.innerHTML = HTML.replace(/[\s\S]*<body>/, '').replace(/<\/body>[\s\S]*/, '');
+
+  // Capture this module instance's DOMContentLoaded handler instead of dispatching
+  // the event: `document` outlives jest.resetModules(), so every previous load()
+  // would otherwise still be listening and re-run with ITS captured browser branch
+  // — the earlier Chrome pass would strip the Firefox glyph this one just rendered.
+  let onReady = null;
+  const spy = jest.spyOn(document, 'addEventListener')
+    .mockImplementation((type, fn) => { if (type === 'DOMContentLoaded') onReady = fn; });
   require('../src/welcome');
-  document.dispatchEvent(new Event('DOMContentLoaded'));
+  spy.mockRestore();
+  onReady();
 }
 
 afterEach(() => { delete global.SITES; setUa(REAL_UA); });
@@ -80,6 +89,30 @@ describe('welcome page rendering', () => {
     test('every other browser keeps the Chrome wording', () => {
       load();
       expect(txt('wPinBody')).toBe('welcomePinBody');
+    });
+
+    // Both browsers draw their extensions button differently; exactly one glyph
+    // must survive, or the two would stack inside the same 38px tile.
+    test('each browser keeps only its own extensions glyph', () => {
+      load({ ua: FIREFOX_UA });
+      expect(document.querySelector('.ico-firefox')).not.toBeNull();
+      expect(document.querySelector('.ico-chrome')).toBeNull();
+
+      load();
+      expect(document.querySelector('.ico-chrome')).not.toBeNull();
+      expect(document.querySelector('.ico-firefox')).toBeNull();
+    });
+
+    test('the outline glyph is stroked, not filled', () => {
+      // `.glyph svg { fill }` would flood the outline, so welcome.css has to
+      // override fill AND own the stroke width — a presentation attribute on the
+      // markup would lose to it.
+      const css = fs.readFileSync(path.join(ROOT, 'src/welcome.css'), 'utf8');
+      const rule = css.slice(css.indexOf('.glyph svg.ico-firefox {'));
+      const body = rule.slice(0, rule.indexOf('}'));
+      expect(body).toMatch(/fill:\s*none/);
+      expect(body).toMatch(/stroke:\s*var\(--muted\)/);
+      expect(body).toMatch(/stroke-width:/);
     });
 
     test('the Firefox text quotes Firefox\'s own Pin to Toolbar label', () => {


### PR DESCRIPTION
Step 1 already swapped its **wording** per browser (#37); the icon beside it still showed Chrome's filled Material Symbols `extension` everywhere. Now it shows Firefox's own outline puzzle on Firefox.

Both glyphs ship in the HTML and `pickExtensionsGlyph()` removes the one that does not apply — the same `/Firefox/` branch the wording already uses. Exactly one has to survive, or the two stack inside the same 38px tile; a test asserts that in both directions.

## Two details worth knowing

- **The outline needs `fill: none` *and* its `stroke-width` in `welcome.css`.** Presentation attributes on the markup lose to any CSS rule, so the existing `.glyph svg { fill: var(--muted) }` would have flooded the shape into a solid blob. It is also drawn a touch larger than the filled glyph so the two carry the same visual weight next to the pin.

- **A latent flaw in the test harness surfaced here and is fixed.** `document` outlives `jest.resetModules()`, so every previous `load()` was still listening for `DOMContentLoaded` and re-ran with *its* captured browser branch — an earlier Chrome pass stripped the Firefox glyph a later Firefox pass had just rendered. `load()` now captures and invokes only the current module instance's handler instead of dispatching the event. Nothing else in the suite was relying on the old behaviour (541 green either way), but the next per-browser or per-state branch would have hit the same trap.

## Verification

541 tests green; `python build.py --yes` clean; both variants rendered from `dist/ai-folders/firefox/` and inspected at 4× — the outline reads at the same weight as the pin, and Chrome still gets the filled glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)