### PR TITLE
fix(welcome): correct the Firefox puzzle shape

### DIFF
--- a/src/welcome.css
+++ b/src/welcome.css
@@ -144,17 +144,20 @@ img { max-width: 100%; display: block; }
   border: 1px solid var(--card-border);
 }
 .glyph svg { width: 22px; height: 22px; fill: var(--muted); }
-/* Firefox's extensions glyph is an outline, not a solid. Its stroke width has to
-   be declared here and not left as a presentation attribute: any CSS rule beats a
-   presentation attribute, so `fill` above would otherwise flood the shape. Nudged
-   a little larger than the filled Material glyph so the two read at the same
-   visual weight in the 38px tile. */
+/* Firefox's extensions glyph is an outline, not a solid. The source art is a filled
+   silhouette, so `fill: none` + a stroke traces its perimeter — that is what makes
+   the outline. Both must be declared here rather than left as presentation
+   attributes on the markup: any CSS rule beats a presentation attribute, so the
+   `fill` above would otherwise flood the shape back into a solid.
+   stroke-width is in viewBox units (48 here), so 3 renders as 3/48 × 24px = 1.5px —
+   matching the weight of the filled Material glyph in the same 38px tile. Rescale it
+   if the artwork is ever swapped for one with a different viewBox. */
 .glyph svg.ico-firefox {
   width: 24px;
   height: 24px;
   fill: none;
   stroke: var(--muted);
-  stroke-width: 34;
+  stroke-width: 3;
   stroke-linecap: round;
   stroke-linejoin: round;
 }

--- a/src/welcome.html
+++ b/src/welcome.html
@@ -44,15 +44,17 @@
                are here and welcome.js drops the one that does not apply:
                  .ico-chrome  Material Symbols "extension", 24dp wght400 (hence the
                               0 -960 960 960 viewBox — not a typo)
-                 .ico-firefox the outline puzzle Firefox shows for its Extensions
-                              panel; stroked rather than filled, styled in welcome.css
+                 .ico-firefox the single puzzle piece Firefox shows for its Extensions
+                              panel. The source art is a filled silhouette; welcome.css
+                              strokes its perimeter instead of filling it, which is what
+                              turns it into the outline that matches the pin beside it.
                The pin beside them is Material Symbols "keep" and is shared. -->
           <span class="glyph">
             <svg class="ico-chrome" viewBox="0 -960 960 960" role="img" aria-hidden="true">
               <path d="M200-200h520v-184l45-22q16-8 25.5-22t9.5-32q0-17-9.5-31.5T765-514l-45-21v-185H528l-10-68q-3-22-19.5-37T460-840q-23 0-39.5 15T401-788l-10 68H200v86q56 21 88 68t32 106q0 60-32 107t-88 68v85Zm0 80q-34 0-57-23t-23-57v-152q48 0 84-30.5t36-77.5q0-46-36-76t-84-32v-152q0-33 23.5-56.5T200-800h122q7-51 46-85.5t92-34.5q52 0 91 34.5t47 85.5h122q33 0 56.5 23.5T800-720v134q36 18 58 52t22 74q0 41-22 75t-58 51v134q0 34-23.5 57T720-120H200Zm300-340Z"/>
             </svg>
-            <svg class="ico-firefox" viewBox="0 0 512 512" role="img" aria-hidden="true">
-              <path d="M413.66,246.1H386a2,2,0,0,1-2-2V166.86A38.86,38.86,0,0,0,345.14,128H267.9a2,2,0,0,1-2-2V98.34c0-27.14-21.5-49.86-48.64-50.33a49.53,49.53,0,0,0-50.4,49.51V126a2,2,0,0,1-2,2H87.62A39.74,39.74,0,0,0,48,167.62V238a2,2,0,0,0,2,2H76.91c29.37,0,53.68,25.48,54.09,54.85.42,29.87-23.51,57.15-53.29,57.15H50a2,2,0,0,0-2,2v70.38A39.74,39.74,0,0,0,87.62,464H158a2,2,0,0,0,2-2V441.07c0-30.28,24.75-56.35,55-57.06,30.1-.7,57,20.31,57,50.28V462a2,2,0,0,0,2,2h71.14A38.86,38.86,0,0,0,384,425.14v-78a2,2,0,0,1,2-2h28.48c27.63,0,49.52-22.67,49.52-50.4S440.8,246.1,413.66,246.1Z"/>
+            <svg class="ico-firefox" viewBox="0 0 48 48" role="img" aria-hidden="true">
+              <path d="M39,15c0-2.2-1.8-4-4-4h-6c-0.7,0-1.1-0.8-0.7-1.4c0.6-1,0.9-2.2,0.6-3.5c-0.4-2-1.9-3.6-3.8-4C21.8,1.4,19,3.9,19,7c0,1,0.3,1.8,0.7,2.6c0.4,0.6,0,1.4-0.8,1.4h-6c-2.2,0-4,1.8-4,4v7c0,0.7,0.8,1.1,1.4,0.7c1-0.6,2.2-0.9,3.5-0.6c2,0.4,3.6,1.9,4,3.8c0.7,3.2-1.8,6.1-4.9,6.1c-1,0-1.8-0.3-2.6-0.7C9.8,30.9,9,31.3,9,32v6c0,2.2,1.8,4,4,4h22c2.2,0,4-1.8,4-4V15z"/>
             </svg>
           </span>
           <span class="glyph-sep" aria-hidden="true">


### PR DESCRIPTION
Same outline treatment, right silhouette: a single puzzle piece with the tab on top and the socket on the left — what Firefox draws for its Extensions panel — instead of the rounded-square puzzle that shipped in #38.

The source art is a filled silhouette, so `welcome.css` strokes its perimeter rather than filling it; that is what turns it into an outline in the first place.

One thing worth recording: `stroke-width` is in **viewBox units**, and the viewBox went from 512 to 48. The old `34` would have rendered as a 17px slab on the new artwork, so it becomes `3` — which keeps the rendered weight at 1.5px, unchanged next to the pin. The CSS now says so, so the next swap rescales it instead of inheriting a number that no longer means anything.

## Verification

543 tests green; `python build.py --yes` clean; rendered from `dist/ai-folders/firefox/` and inspected at 4× — the outline sits at the same weight as the pin, and Chrome still gets the filled Material glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)