### PR TITLE
fix(tools): resolve the repo root instead of hardcoding it

### DIFF
--- a/tools/stats-collector/README.md
+++ b/tools/stats-collector/README.md
@@ -35,7 +35,8 @@ This generates the host manifest from `com.geminifoldersantigravity.filereader.e
 (injecting this machine's absolute path) and writes one registry key under
 `HKCU\Software\Mozilla\NativeMessagingHosts` pointing at it. The generated
 manifest is gitignored — only the `.example.json` template is committed. No
-admin rights required.
+admin rights required. **Re-run it after moving or renaming the repo**: both the
+manifest and the registry value record the old absolute path.
 
 ## Loading in Firefox
 

--- a/tools/stats-collector/native/filereader.py
+++ b/tools/stats-collector/native/filereader.py
@@ -8,13 +8,20 @@ Protocol: each message is a 4-byte little-endian length prefix + UTF-8 JSON.
 Binary responses are streamed as {"ok", "chunk", "done"} messages: Firefox
 kills the connection on any native→extension message over 1 MB, and the
 base64 of a marketing screenshot exceeds that.
+
+It also answers {"cmd": "repo_root"} with the absolute path of the repo it
+lives in: an extension only knows its moz-extension:// origin, never its path
+on disk, so this is how the publisher finds dist/ without a hardcoded path.
 """
 import base64
 import sys
 import json
 import struct
+from pathlib import Path
 
 BINARY_CHUNK = 256 * 1024  # base64 chars per message, well under the 1 MB cap
+# <repo>/tools/stats-collector/native/filereader.py → up 3 levels.
+REPO_ROOT = str(Path(__file__).resolve().parents[3])
 
 
 def send(msg):
@@ -38,6 +45,9 @@ while True:
     if msg is None:
         break
     try:
+        if msg.get("cmd") == "repo_root":
+            send({"ok": True, "repo_root": REPO_ROOT})
+            continue
         path = msg["path"]
         if msg.get("binary"):
             with open(path, "rb") as f:

--- a/tools/stats-collector/native/install-native-host.ps1
+++ b/tools/stats-collector/native/install-native-host.ps1
@@ -1,10 +1,13 @@
-# Registers the CWS Stats Collector native messaging host in Firefox.
-# Run once from this directory:  .\install-native-host.ps1
+# Registers the native messaging host (CWS Stats Collector + Store Publisher)
+# in Firefox. Run once from this directory:  .\install-native-host.ps1
 #
 # The native host manifest needs an absolute path to filereader.bat, which is
 # machine-specific. Rather than commit that path, we generate the manifest here
 # from the committed *.example.json template, then register it. The generated
 # manifest is gitignored.
+#
+# RE-RUN THIS AFTER MOVING OR RENAMING THE REPO: the manifest and the registry
+# value both point at the old location, and nothing else in the tools does.
 
 $templatePath = Join-Path $PSScriptRoot "com.geminifoldersantigravity.filereader.example.json"
 $manifestPath = Join-Path $PSScriptRoot "com.geminifoldersantigravity.filereader.json"

--- a/tools/store-publisher/README.md
+++ b/tools/store-publisher/README.md
@@ -30,13 +30,19 @@ manual, by design.
 
 ## Setup (one-time)
 
-1. `cp config.example.json config.json` and fill in `publisher_id` and
-   `repo_root` (absolute path to this repo). `config.json` is gitignored.
+1. `cp config.example.json config.json` and fill in `publisher_id`.
+   `config.json` is gitignored. No repo path to fill in: the extension asks the
+   native host where the repo is (the host lives in it), and `amo_publish.py`
+   derives it from its own location — so the repo can be moved or renamed.
+   An optional `repo_root` still overrides both, to read another checkout.
 2. Native messaging host: the tool shares the stats-collector host
    (`filereader.py`, which also serves PNG bytes as base64). If you already
    installed it for stats-collector you have nothing to do — the host manifest
    now allowlists `store-publisher@dev.local` too. Otherwise run once:
    `tools\stats-collector\native\install-native-host.ps1`.
+   **Re-run that script after moving the repo**: the host manifest and the
+   registry entry record absolute paths, and this is the only thing a move
+   breaks. Both tools report the repo root they resolved at the start of a run.
 3. Load in Firefox: `about:debugging` → This Firefox → Load Temporary Add-on →
    select `tools/store-publisher/manifest.json`. Reload after each Firefox
    restart. Be signed into the Google account with publisher access in this

--- a/tools/store-publisher/amo_publish.py
+++ b/tools/store-publisher/amo_publish.py
@@ -43,6 +43,10 @@ from pathlib import Path
 
 API_BASE = "https://addons.mozilla.org/api/v5"
 TOOL_DIR = Path(__file__).resolve().parent
+# The repo the script itself lives in (tools/store-publisher/ → tools/ → root),
+# so moving or renaming the checkout doesn't break anything. config.json may
+# still pin "repo_root" to read another checkout's dist/; see resolve_repo_root.
+REPO_ROOT = TOOL_DIR.parents[1]
 # Records the screenshot set last uploaded per add-on, so an unchanged gallery
 # is skipped instead of torn down and re-uploaded (AMO throttles writes hard).
 STATE_FILE = TOOL_DIR / ".amo-previews-state.json"  # gitignored
@@ -73,6 +77,21 @@ def load_locales():
 
 def promo_txt_name(internal):
     return "PromoCN.txt" if internal == "zh_CN" else f"Promo{internal.upper()}.txt"
+
+
+def resolve_repo_root(config):
+    """Where dist/ lives. Derived from this file's location by default — an
+    override in config.json is only for pointing at a different checkout."""
+    configured = (config.get("repo_root") or "").strip()
+    if not configured:
+        return REPO_ROOT
+    root = Path(configured).expanduser()
+    if not root.is_dir():
+        sys.exit(f'config.json "repo_root" points at a directory that does not exist:\n'
+                 f"  {root}\n"
+                 f"Drop the key to use the repo this script lives in ({REPO_ROOT}), "
+                 f"or fix the path.")
+    return root
 
 
 # ── AMO API client (JWT auth, stdlib HTTP) ────────────────────────────────────
@@ -174,6 +193,8 @@ def api_request(creds, method, path, json_body=None, multipart=None, max_retries
 
 def build_descriptions(marketing_dir, locales):
     """Reads every supported locale's promo text. Returns {amo_code: text}."""
+    if not marketing_dir.is_dir():
+        sys.exit(f"Marketing dir not found: {marketing_dir} — run `python build.py` first.")
     out, skipped = {}, []
     for loc in locales:
         if not loc["amo"]:
@@ -359,11 +380,13 @@ def main():
     if not item:
         sys.exit(f'Item "{args.item}" not in config.json')
     guid = item["amo_guid"]
-    marketing_dir = Path(config["repo_root"]) / "dist" / item["slug"] / "marketing_firefox"
-    locales_dir = Path(config["repo_root"]) / "dist" / item["slug"] / "firefox" / "_locales"
+    repo_root = resolve_repo_root(config)
+    marketing_dir = repo_root / "dist" / item["slug"] / "marketing_firefox"
+    locales_dir = repo_root / "dist" / item["slug"] / "firefox" / "_locales"
     locales = load_locales()
 
     print(f'{"APPLY" if args.apply else "DRY-RUN"} — {item["name"]} ({guid})')
+    print(f"Repo root: {repo_root}")
     addon = api_request(creds, "GET", f"/addons/addon/{guid}/")
     current_desc = addon.get("description") or {}
     if isinstance(current_desc, dict):

--- a/tools/store-publisher/background.js
+++ b/tools/store-publisher/background.js
@@ -16,15 +16,22 @@ const DRIVERS = { cws: CwsDriver };
 
 // ── native messaging (shared host with stats-collector) ───────────────────────
 
-// Binary reads arrive as a stream of {ok, chunk, done} messages: Firefox caps
-// native→extension messages at 1 MB and a screenshot's base64 exceeds that.
-function readFileNative(path, binary = false) {
+const NATIVE_HOST = 'com.geminifoldersantigravity.filereader';
+// The host manifest records an absolute path to filereader.bat, so moving the
+// repo invalidates it — that's what a connect failure usually means.
+const NATIVE_HINT = 'run tools/stats-collector/native/install-native-host.ps1 '
+  + '(re-run it after moving or renaming the repo).';
+
+// One request/response over the native host. Binary reads arrive as a stream of
+// {ok, chunk, done} messages: Firefox caps native→extension messages at 1 MB and
+// a screenshot's base64 exceeds that, so the chunks are joined back here.
+function nativeRequest(payload) {
   return new Promise((resolve, reject) => {
     let port;
     try {
-      port = chrome.runtime.connectNative('com.geminifoldersantigravity.filereader');
+      port = chrome.runtime.connectNative(NATIVE_HOST);
     } catch (e) {
-      reject(new Error('Native host unavailable — run tools/stats-collector/native/install-native-host.ps1 first. ' + e.message));
+      reject(new Error('Native host unavailable — ' + NATIVE_HINT + ' ' + e.message));
       return;
     }
     let settled = false;
@@ -36,20 +43,42 @@ function readFileNative(path, binary = false) {
     };
     const parts = [];
     port.onMessage.addListener(msg => {
-      if (!msg.ok) { finish(reject, new Error(`Native read error (${path}): ${msg.error}`)); return; }
-      if (msg.chunk !== undefined) {
-        parts.push(msg.chunk);
-        if (msg.done) finish(resolve, parts.join(''));
+      if (!msg.ok) {
+        finish(reject, new Error(`Native error (${payload.path ?? payload.cmd}): ${msg.error}`));
         return;
       }
-      finish(resolve, msg.content);
+      if (msg.chunk !== undefined) {
+        parts.push(msg.chunk);
+        if (msg.done) finish(resolve, { ...msg, content: parts.join('') });
+        return;
+      }
+      finish(resolve, msg);
     });
     port.onDisconnect.addListener(() => {
       const err = chrome.runtime.lastError?.message ?? 'disconnected';
-      finish(reject, new Error('Native host disconnected: ' + err));
+      finish(reject, new Error(`Native host disconnected: ${err} — ${NATIVE_HINT}`));
     });
-    port.postMessage(binary ? { path, binary: true } : { path });
+    port.postMessage(payload);
   });
+}
+
+function readFileNative(path, binary = false) {
+  return nativeRequest(binary ? { path, binary: true } : { path }).then(msg => msg.content);
+}
+
+// An extension only knows its moz-extension:// origin, never its own path on
+// disk, so the repo root comes from the native host — which does live inside the
+// repo. `repo_root` in config.json stays supported as an override (a checkout
+// elsewhere), but it is no longer required, so moving the repo breaks nothing.
+async function resolveRepoRoot(config) {
+  const configured = (config.repo_root || '').trim();
+  if (configured) return configured;
+  const { repo_root: root } = await nativeRequest({ cmd: 'repo_root' });
+  if (!root) {
+    throw new Error('Native host returned no repo root — update '
+      + 'tools/stats-collector/native/filereader.py, or set "repo_root" in config.json.');
+  }
+  return root;
 }
 
 // ── tab helpers ───────────────────────────────────────────────────────────────
@@ -185,7 +214,14 @@ async function runPublish(config, opts, onProgress) {
   if (!item) throw new Error(`Item "${opts.itemSlug}" not in config.json`);
 
   const locales = filterLocales(opts.localeFilter);
-  const marketingDir = joinPath(config.repo_root, driver.marketingDirParts(item));
+  // Resolved lazily: a pure probe touches no local file, so it must keep working
+  // even when the native host is unregistered (e.g. right after a repo move).
+  let marketingDir = null;
+  if (!opts.probeOnly) {
+    const repoRoot = await resolveRepoRoot(config);
+    marketingDir = joinPath(repoRoot, driver.marketingDirParts(item));
+    onProgress(`Repo root: ${repoRoot}`);
+  }
 
   // Pre-flight: read every promo text up front so a missing/stale dist file
   // aborts the run before the page is touched. (Skipped for a pure probe.)

--- a/tools/store-publisher/config.example.json
+++ b/tools/store-publisher/config.example.json
@@ -1,7 +1,6 @@
 {
-  "_comment": "Copy to config.json and fill in your values. config.json is gitignored (publisher UUID, AMO API secret, local absolute path). repo_root must point at the repo so the tools can read dist/<slug>/marketing_*/. AMO credentials come from https://addons.mozilla.org/developers/addon/api/key/",
+  "_comment": "Copy to config.json and fill in your values. config.json is gitignored (publisher UUID, AMO API secret). Both tools find dist/<slug>/marketing_*/ on their own — amo_publish.py from its own location, the CWS extension by asking the native host — so the repo can be moved freely. Add \"repo_root\" only to read ANOTHER checkout's dist/. AMO credentials come from https://addons.mozilla.org/developers/addon/api/key/",
   "publisher_id": "YOUR_PUBLISHER_UUID_HERE",
-  "repo_root": "C:\\path\\to\\GeminiFolders",
   "amo": {
     "jwt_issuer": "YOUR_AMO_JWT_ISSUER (user:…)",
     "jwt_secret": "YOUR_AMO_JWT_SECRET"


### PR DESCRIPTION
Moving the checkout broke both store publishers: `amo_publish.py` and the CWS
extension both read an absolute `repo_root` out of `config.json`, and the native
messaging host manifest pointed at the old `filereader.bat`.

## Changes

- **`amo_publish.py`** derives the root from its own location
  (`tools/store-publisher/` → `../..`). `repo_root` in `config.json` stays
  supported as an override for reading another checkout, and now fails with a
  readable message when it points nowhere; a missing `dist/marketing_firefox/`
  says to run `build.py`, mirroring the existing `_locales` check.
- **`filereader.py`** answers `{"cmd": "repo_root"}`. An extension only knows its
  `moz-extension://` origin, never its path on disk, so the native host — which
  lives inside the repo — is the only component that can tell it where `dist/` is.
- **`store-publisher/background.js`** asks the host when `config.repo_root` is
  unset. The port plumbing is extracted into `nativeRequest()` (`readFileNative`
  becomes a one-line wrapper), and the root is resolved lazily so a pure
  **Probe page** run still works with the host unregistered.
- Both tools print the resolved root at the start of a run.

## What still needs a manual step after a move

Firefox requires an absolute path in the native host manifest, and the `HKCU`
key points at that manifest — irreducible. `install-native-host.ps1` regenerates
both; its header and both READMEs now say to re-run it after moving the repo.

## Testing

- `npx jest` — 19 suites, 543 tests, green.
- Repo-root resolution checked for the auto, blank and override cases.
- Native host exercised end to end: `{"cmd":"repo_root"}`, a text read, and a
  missing file (clean error).
- Host re-registered at the new path; manifest and registry value verified.
- Build and the publisher changes tested manually by @dlamarre-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)