### PR TITLE
chore(deps-dev): bump js-yaml from 3.15.0 to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3175,9 +3175,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears the last open `npm audit` finding, surfaced while validating #42.

**Advisory:** [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) / CVE-2026-59870 — quadratic CPU consumption in `!!omap` resolution (high, CWE-407, CVSS 7.5). Vulnerable range is `>=3.0.0 <3.15.1`, so the 3.x patch release clears it; no major-version move needed.

**Blast radius:** none in the shipped extensions. `js-yaml` is dev-only and transitive:

```
jest -> @jest/core -> @jest/transform -> babel-plugin-istanbul
     -> @istanbuljs/load-nyc-config -> js-yaml
```

`@istanbuljs/load-nyc-config@1.1.0` asks for `^3.13.1`, which 3.15.1 satisfies — so this is a `package-lock.json`-only change. `package.json` is untouched and jest stays on 29.7.0.

**Verification**
- `npm ci` — clean, integrity hashes verified against the registry
- `npm audit` — 0 vulnerabilities (was 1 high)
- `npx jest` — 543 tests, 19 suites, all green
- `npx jest --coverage` — also green, exercising the `babel-plugin-istanbul` path that actually consumes `js-yaml`
- `python build.py --yes` — all four zips build

All 4 required checks ran and passed on this branch, including the three `Analyze` jobs — unlike #42, where CodeQL reported *skipping* on the same kind of lockfile-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)