### PR TITLE
chore: ignore jest's coverage/ output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 Marketing/reddit-launch-plan.md
 
 node_modules/
+coverage/
 
 __pycache__/
 *.pyc


### PR DESCRIPTION
`npx jest --coverage` writes a `coverage/` directory at the repo root, and nothing ignored it — so running the documented coverage command left a few hundred untracked files in `git status`, easy to sweep into an unrelated commit with a broad `git add`. Noticed while verifying #45, where coverage was the run that actually exercised the patched `js-yaml` path.

One line, grouped with `node_modules/` as the other npm-generated tree.

**Verification:** ran `npx jest --coverage` (543 tests green) and confirmed `git status` then shows only the `.gitignore` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)