### PR TITLE
feat(folders): clicking a saved conversation focuses its open tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,18 @@ git checkout main && git pull --ff-only
   permission is requested **scoped to the entered origin only** (the broad
   `optional_host_permissions http(s)://*/*` is just the manifest pattern needed to
   request a dynamic origin at runtime — nothing is granted by default).
+- **Opening a saved conversation** (`openConversation` / `findOpenConversationTab`,
+  folders.js): a plain click activates the tab already showing that URL instead of
+  spawning a duplicate; middle-click and Shift-click are left 100% native, which is
+  why the `<a href target="_blank">` must stay. **Never add the `"tabs"` permission
+  for this** — it triggers the "read your browsing history" warning and re-prompts
+  every installed user. Without it `chrome.tabs.query({})` still lists every tab but
+  populates `tab.url` only for hosts in `host_permissions`, so a tab we cannot read
+  is by construction not ours and is never touched; `isSafeUrl` then excludes
+  `chrome-extension:` (the popup's own page, `import.html`, `welcome.html`). The
+  `url:` filter of `tabs.query` is off-limits for the same reason — filter in JS.
+  Consequence to accept, not fix: a local-LLM conversation (AF) and everything on
+  Firefox before the user grants host permissions degrade silently to "new tab".
 
 ---
 

--- a/src/folders.js
+++ b/src/folders.js
@@ -305,6 +305,17 @@ function displayFolders(openFoldersArg = [], searchTerm = "") {
         link.title = chat.title;
         link.textContent = chat.title;
 
+        // Plain click: reuse the tab already showing this conversation instead of
+        // spawning a duplicate. Middle-click (auxclick, never listened to) and
+        // Shift-click stay 100% native — that is the escape hatch, so keeping the
+        // href/target="_blank" above intact is load-bearing, not decorative.
+        link.addEventListener('click', (e) => {
+          if (e.button !== 0 || e.shiftKey || e.altKey) return;
+          if (link.href === 'about:blank') return;   // URL rejected by isSafeUrl
+          e.preventDefault();
+          openConversation(chat.url);
+        });
+
         link.setAttribute('draggable', 'false');
 
         // Container for conversation buttons
@@ -563,7 +574,56 @@ async function openFolderInTabGroup(folderName, chats) {
   }
 }
 
+// Finds an open tab already showing `url`, or null.
+//
+// SECURITY INVARIANT — do not "fix" this by adding the "tabs" permission (it
+// triggers the "read your browsing history" warning and re-prompts every
+// installed user). Without it, chrome.tabs.query({}) still lists every tab but
+// only populates tab.url for hosts covered by host_permissions, so a tab whose
+// URL we cannot read is by construction not one of ours and is never touched.
+// The permission model does the filtering for us. isSafeUrl is the second
+// filter: it rejects chrome-extension:, so the popup's own page, import.html
+// and welcome.html can never be matched.
+// The url: filter of tabs.query is off-limits for the same reason — it requires
+// "tabs". Filter in JS instead.
+async function findOpenConversationTab(url) {
+  let tabs;
+  try {
+    tabs = await chrome.tabs.query({});
+  } catch (error) {
+    return null;
+  }
+  if (!Array.isArray(tabs)) return null;
+  const wanted = normalizeUrl(url);
+  return tabs.find(t => t && t.url && isSafeUrl(t.url) && normalizeUrl(t.url) === wanted) || null;
+}
+
+// Opens a saved conversation: activates the tab already showing it, otherwise
+// opens a new one (the pre-existing behaviour).
+async function openConversation(url) {
+  try {
+    const found = await findOpenConversationTab(url);
+    if (found) {
+      await chrome.tabs.update(found.id, { active: true });
+      // Activating a tab in another window doesn't raise that window.
+      // windows.update requires no permission.
+      if (found.windowId != null && chrome.windows) {
+        await chrome.windows.update(found.windowId, { focused: true });
+      }
+    } else {
+      await chrome.tabs.create({ url });
+    }
+  } catch (error) {
+    // The tab died between the query and the update, or the API rejected.
+    try { await chrome.tabs.create({ url }); } catch (e) { /* nothing left to try */ }
+  }
+  // After the awaits, never before: tearing down the popup page can drop
+  // in-flight extension API calls.
+  window.close();
+}
+
 window.displayFolders = displayFolders;
+window.openConversation = openConversation;
 
 if (typeof module !== 'undefined') {
   // In Node/Jest the sort helpers are globals in the browser (from utils.js),
@@ -582,6 +642,8 @@ if (typeof module !== 'undefined') {
     togglePin,
     renameFolder,
     openFolderInTabGroup,
+    findOpenConversationTab,
+    openConversation,
   };
 }
 

--- a/tests/folders.test.js
+++ b/tests/folders.test.js
@@ -1,7 +1,7 @@
 // folders.js functions depend on globals from utils.js and the DOM.
 // We mock those globals here so tests run in isolation.
 
-const { displayFolders, deleteChat, moveChat, togglePin, renameFolder, renameChat, openFolderInTabGroup } = require('../src/folders');
+const { displayFolders, deleteChat, moveChat, togglePin, renameFolder, renameChat, openFolderInTabGroup, findOpenConversationTab, openConversation } = require('../src/folders');
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -38,6 +38,9 @@ beforeEach(() => {
   global.normalizeUrl = jest.fn((url) => url.split('?')[0].split('#')[0]);
   global.isSafeUrl = jest.fn(() => true);
   global.window.showCustomModal = jest.fn();
+  // openConversation closes the popup when it is done; in jsdom the real
+  // window.close() would tear the test window down.
+  global.window.close = jest.fn();
 
   // Provide all DOM elements that displayFolders (called after each mutation)
   // reads at the top of its body. Without them it throws on null refs.
@@ -340,6 +343,172 @@ describe('openFolderInTabGroup', () => {
     await openFolderInTabGroup('Big', chats);
 
     expect(global.window.showCustomModal).toHaveBeenCalled();
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openConversation / findOpenConversationTab
+// ---------------------------------------------------------------------------
+
+describe('openConversation', () => {
+  const URL_A = 'https://gemini.google.com/app/aaa';
+
+  beforeEach(() => {
+    chrome.tabs.create = jest.fn(() => Promise.resolve({ id: 99 }));
+    chrome.tabs.update = jest.fn(() => Promise.resolve());
+    chrome.tabs.query = jest.fn(() => Promise.resolve([]));
+    chrome.windows.update = jest.fn(() => Promise.resolve());
+  });
+
+  test('activates the tab already showing the conversation instead of duplicating it', async () => {
+    chrome.tabs.query.mockResolvedValue([
+      { id: 3, windowId: 1, url: 'https://gemini.google.com/app/other' },
+      { id: 7, windowId: 1, url: URL_A },
+    ]);
+
+    await openConversation(URL_A);
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(7, { active: true });
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
+  test('matches ignoring query and hash (same identity as save dedup)', async () => {
+    chrome.tabs.query.mockResolvedValue([{ id: 7, windowId: 1, url: `${URL_A}?hl=fr#top` }]);
+
+    await openConversation(URL_A);
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(7, { active: true });
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
+  test('raises the window when the matching tab lives in another one', async () => {
+    chrome.tabs.query.mockResolvedValue([{ id: 7, windowId: 42, url: URL_A }]);
+
+    await openConversation(URL_A);
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(7, { active: true });
+    expect(chrome.windows.update).toHaveBeenCalledWith(42, { focused: true });
+  });
+
+  test('opens a new tab when the conversation is not open anywhere', async () => {
+    chrome.tabs.query.mockResolvedValue([{ id: 3, windowId: 1, url: 'https://gemini.google.com/app/other' }]);
+
+    await openConversation(URL_A);
+
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: URL_A });
+    expect(chrome.tabs.update).not.toHaveBeenCalled();
+  });
+
+  test('never matches a tab whose URL we cannot read (no host permission)', async () => {
+    chrome.tabs.query.mockResolvedValue([{ id: 3, windowId: 1 }, { id: 4, windowId: 1, url: undefined }]);
+
+    await openConversation(URL_A);
+
+    expect(chrome.tabs.update).not.toHaveBeenCalled();
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: URL_A });
+  });
+
+  test('never matches an extension page (popup / import / welcome)', async () => {
+    // The real http(s)-only check: this is what excludes chrome-extension:.
+    global.isSafeUrl = jest.fn((url) => {
+      try { return /^https?:$/.test(new URL(url).protocol); } catch { return false; }
+    });
+    chrome.tabs.query.mockResolvedValue([
+      { id: 5, windowId: 1, url: 'chrome-extension://test-id/popup.html' },
+    ]);
+
+    await openConversation('chrome-extension://test-id/popup.html');
+
+    expect(chrome.tabs.update).not.toHaveBeenCalled();
+  });
+
+  test('falls back to a new tab when the matching tab dies mid-flight', async () => {
+    chrome.tabs.query.mockResolvedValue([{ id: 7, windowId: 1, url: URL_A }]);
+    chrome.tabs.update.mockRejectedValue(new Error('No tab with id: 7'));
+
+    await openConversation(URL_A);
+
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: URL_A });
+  });
+
+  test('falls back to a new tab when tabs.query is unavailable', async () => {
+    chrome.tabs.query.mockRejectedValue(new Error('nope'));
+
+    expect(await findOpenConversationTab(URL_A)).toBeNull();
+
+    await openConversation(URL_A);
+    expect(chrome.tabs.create).toHaveBeenCalledWith({ url: URL_A });
+  });
+
+  test('closes the popup only after the tab work is done', async () => {
+    chrome.tabs.query.mockResolvedValue([{ id: 7, windowId: 1, url: URL_A }]);
+    const order = [];
+    chrome.tabs.update = jest.fn(() => { order.push('update'); return Promise.resolve(); });
+    global.window.close = jest.fn(() => order.push('close'));
+
+    await openConversation(URL_A);
+
+    expect(order).toEqual(['update', 'close']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .chat-link click handling
+// ---------------------------------------------------------------------------
+
+describe('chat link click', () => {
+  const URL_A = 'https://gemini.google.com/app/aaa';
+
+  function renderOneChat() {
+    setupStorage({ Dev: makeFolder(['Chat 1', 'aaa']) }, [], ['Dev']);
+    displayFolders(['Dev']);
+    return document.querySelector('.chat-link');
+  }
+
+  function clickWith(link, init = {}) {
+    const e = new window.MouseEvent('click', { bubbles: true, cancelable: true, ...init });
+    link.dispatchEvent(e);
+    return e;
+  }
+
+  beforeEach(() => {
+    chrome.tabs.create = jest.fn(() => Promise.resolve({ id: 99 }));
+    chrome.tabs.update = jest.fn(() => Promise.resolve());
+    chrome.tabs.query = jest.fn(() => Promise.resolve([]));
+    chrome.windows.update = jest.fn(() => Promise.resolve());
+  });
+
+  test('keeps the href and target="_blank" (a11y + native middle-click)', () => {
+    const link = renderOneChat();
+    expect(link.getAttribute('href')).toBe(URL_A);
+    expect(link.target).toBe('_blank');
+  });
+
+  test('a plain click is handled by the extension', () => {
+    const e = clickWith(renderOneChat());
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  test.each([
+    ['shift-click (native new window)', { shiftKey: true }],
+    ['alt-click', { altKey: true }],
+    ['middle-click', { button: 1 }],
+  ])('%s stays fully native', (_label, init) => {
+    const e = clickWith(renderOneChat(), init);
+    expect(e.defaultPrevented).toBe(false);
+    expect(chrome.tabs.query).not.toHaveBeenCalled();
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+    expect(chrome.tabs.update).not.toHaveBeenCalled();
+  });
+
+  test('an unsafe stored URL is never sent to the tabs API', () => {
+    global.isSafeUrl = jest.fn(() => false);   // href becomes about:blank
+    const link = renderOneChat();
+
+    expect(link.getAttribute('href')).toBe('about:blank');
+    clickWith(link);
+    expect(chrome.tabs.query).not.toHaveBeenCalled();
     expect(chrome.tabs.create).not.toHaveBeenCalled();
   });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -37,6 +37,9 @@ global.chrome = {
   tabGroups: {
     update: jest.fn(),
   },
+  windows: {
+    update: jest.fn(),
+  },
   i18n: {
     getMessage:    jest.fn((key) => key),
     getUILanguage: jest.fn(() => 'en'),


### PR DESCRIPTION
## Why

A Gemini Folders user asked whether conversations could open in the same tab instead of a new one every time. The complaint is literal: the conversation row is a bare `<a target="_blank">` with **no click handler** (`src/folders.js:301`), so the browser does all the work — reopening the same conversation ten times gives ten tabs.

Two distinct needs hide behind that report. This PR ships the harmless half: **no duplicate tabs**. The second half (CTRL/CMD-click to reuse one tab for *different* conversations) follows in a separate PR, since it overwrites whatever the tab was showing.

## What changed

| Gesture | Behaviour |
|---|---|
| Click | tab already showing this URL → activate it (raising its window if elsewhere); otherwise new tab, as before |
| Middle-click | new background tab — **100% native, zero code** |
| Shift-click | new window — **100% native, zero code** |
| Enter on the focused link | same as click |

The `href` and `target="_blank"` are kept untouched on purpose: they are what provide middle-click, "Copy link address" and link semantics for screen readers. The handler only `preventDefault()`s the branch it actually handles.

## No new permission

`"tabs"` is **not** added, and must not be — it triggers the "read your browsing history" warning and re-prompts every installed user. It isn't needed: without it `chrome.tabs.query({})` still lists every tab but populates `tab.url` only for hosts covered by `host_permissions`. So the invariant falls out of the permission model itself:

> A tab whose URL we cannot read is by construction not one of ours, and is never touched.

`isSafeUrl` is the second filter and rejects `chrome-extension:`, so the popup's own page, `import.html` and `welcome.html` can never be matched. The `url:` filter of `tabs.query` is deliberately unused (it would require `"tabs"`); filtering happens in JS. This is now written into CLAUDE.md §7 so nobody later "fixes" it by requesting the permission.

Matching uses the existing `normalizeUrl`, i.e. the same URL identity the save dedup and the import merge already use, rather than inventing a second notion.

## Accepted limits (not bugs)

- An AI Folders conversation on a **local LLM** can't be deduped unless the optional origin grant is active — `tab.url` comes back `undefined`, so you get today's new tab.
- On **Firefox MV3** host permissions are user-grantable; before the grant every tab is unreadable and the behaviour degrades silently to today's.

## Tests

`npx jest` — 558 passing. `python build.py --yes` — clean, both extensions, both browsers.

This adds the **first `.chat-link` coverage in the repo** (there was none): href/`target` regression guard, plain click handled, and shift/alt/middle-click asserted to stay native *and* to never reach the tabs API. Plus the logic cases: dedup in the same window, cross-window window-raise, query/hash-insensitive match, unreadable tab skipped, extension page skipped, tab dying mid-flight → fallback, `tabs.query` unavailable → fallback, and popup closing only after the tab work.

Manual verification still to do on my side per CLAUDE.md §5 (both extensions, both themes, both modes, plus Firefox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)