### PR TITLE
fix(security): ignore page-forged key events in the prompt trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,20 @@ git checkout main && git pull --ff-only
   via `chrome.scripting.executeScript({ world: 'MAIN', func: ... })`. The injected
   prompt text comes from the user's own storage, gated by `getSiteByUrl(sender.url)`
   — a page cannot drive it (no `externally_connectable`).
+  **Every listener starts with `isRealUserEvent(e)` (`e.isTrusted === true`) and that
+  is load-bearing security, not hygiene.** The content script shares the DOM with the
+  page, so script on a supported site could otherwise forge `#` + Space, get the whole
+  prompt list back (an empty prefix matches everything), read the titles out of the
+  composer, then request each body — the entire library, no user interaction. The
+  site check cannot help: the attacker *is* the supported site. `dispatchEvent` can
+  never set `isTrusted`, so the gate is complete. jsdom cannot make a trusted event
+  either, which is why the four handlers (`onSpaceKeydown` etc.) are exported and
+  tested directly while `tests/prompt-trigger-events.test.js` dispatches real
+  synthetic events to prove the gate holds. Behind it, both `background.js` add
+  `isTrustedSender` (own extension id, main frame only) and resolve the target tab
+  via `resolveTriggerTabId` — AF's active-tab fallback for Firefox's dynamically
+  registered local-LLM script only fires when the active tab is the **same origin**
+  that spoke, so a background tab can never drive an injection into another one.
 - **Title extraction:** `extractTitleLogic` + per-site strategies in
   `site-config.js`, run via `executeScript`. Falls back to a heuristic (lowest
   sizeable text field) and logs `console.warn("[Folders extension] …")` when a

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -249,6 +249,36 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
 
 // --- PROMPT TRIGGER (#prefix + Space → bash-like autocomplete/injection) ---
 
+// Defence in depth behind prompt-trigger.js's isTrusted gate. These handlers read
+// the user's prompt library and write it into the page's MAIN world, so they must
+// only ever answer our own content script running in a top-level document.
+// Not a substitute for the isTrusted check: the origin is the attacker's own in
+// that threat model. This only narrows who can reach the handler at all.
+function isTrustedSender(sender) {
+  if (!sender || sender.id !== chrome.runtime.id) return false;
+  // frameId is 0 for the main frame. Reject only when we positively know it is a
+  // subframe — some Firefox paths omit it, and none of these flows target iframes.
+  if (sender.frameId != null && sender.frameId !== 0) return false;
+  return true;
+}
+
+// The tab to inject into. sender.tab may be absent for dynamically-registered
+// content scripts in Firefox (the local-LLM path), hence the active-tab fallback —
+// but only when the active tab is the same origin that spoke, so a background tab
+// can never drive an injection into an unrelated one.
+async function resolveTriggerTabId(sender) {
+  if (sender.tab?.id != null) return sender.tab.id;
+  if (!sender.url) return null;
+  const [active] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!active?.url) return null;
+  try {
+    if (new URL(active.url).origin !== new URL(sender.url).origin) return null;
+  } catch (_) {
+    return null;
+  }
+  return active.id;
+}
+
 async function handlePromptTriggerLookup(message, sender) {
   const { localLlmUrl } = await chrome.storage.sync.get(['localLlmUrl']);
   // sender.tab may be absent for dynamically-registered content scripts in Firefox;
@@ -273,9 +303,7 @@ async function handlePromptTriggerLookup(message, sender) {
   // suggestions only — injection itself still goes through unchanged.
   const noSuggestions = forceClear || !!SITES[siteKey]?.noSuggestions;
 
-  // sender.tab may be absent for dynamically-registered scripts in Firefox;
-  // fall back to the active tab in the current window.
-  const tabId = sender.tab?.id ?? (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id;
+  const tabId = await resolveTriggerTabId(sender);
   if (!tabId) return { status: 'no_match' };
 
   try {
@@ -344,7 +372,7 @@ async function handleSuggestUpdate(message, sender) {
   const names = message.prefix != null
     ? findPromptsByPrefix(data.prompts || {}, message.prefix).map(m => m.name)
     : [];
-  const tabId = sender.tab?.id ?? (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id;
+  const tabId = await resolveTriggerTabId(sender);
   if (!tabId) return { status: 'cleared' };
   try {
     await chrome.scripting.executeScript({
@@ -367,7 +395,7 @@ async function handleCycleTab(message, sender) {
   if (!selectors) return { status: 'error' };
   // No suggestion block is ever shown on these sites, so there is nothing to cycle.
   if (SITES[siteKey]?.forceClear || SITES[siteKey]?.noSuggestions) return { status: 'error' };
-  const tabId = sender.tab?.id ?? (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id;
+  const tabId = await resolveTriggerTabId(sender);
   if (!tabId) return { status: 'error' };
   try {
     await chrome.scripting.executeScript({
@@ -383,6 +411,7 @@ async function handleCycleTab(message, sender) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!isTrustedSender(sender)) return false;
   if (message.action === 'promptTriggerLookup') {
     handlePromptTriggerLookup(message, sender)
       .then(sendResponse)

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -215,7 +215,35 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
 // --- PROMPT TRIGGER (#prefix + Space → bash-like autocomplete/injection) ---
 
+// Defence in depth behind prompt-trigger.js's isTrusted gate. These handlers read
+// the user's prompt library and write it into the page's MAIN world, so they must
+// only ever answer our own content script running in a top-level Gemini document.
+// The manifest already scopes the content script to gemini.google.com; this makes
+// that guarantee explicit here rather than relying on it from a distance (AF has
+// carried the equivalent check since it gained multiple sites).
+function isTrustedSender(sender) {
+  if (!sender || sender.id !== chrome.runtime.id) return false;
+  // frameId is 0 for the main frame. Reject only when we positively know it is a
+  // subframe — some Firefox paths omit it, and none of these flows target iframes.
+  if (sender.frameId != null && sender.frameId !== 0) return false;
+  const url = sender.tab?.url ?? sender.url;
+  try {
+    if (new URL(url).hostname !== 'gemini.google.com') return false;
+  } catch (_) {
+    return false;
+  }
+  return true;
+}
+
+// sender.tab is present for manifest-declared content scripts; guard anyway so a
+// missing tab yields a clean no-op instead of a TypeError swallowed by try/catch.
+function resolveTriggerTabId(sender) {
+  return sender.tab?.id ?? null;
+}
+
 async function handlePromptTriggerLookup(message, sender) {
+  const tabId = resolveTriggerTabId(sender);
+  if (tabId == null) return { status: 'no_match' };
   const data = await new Promise(resolve => loadData({ prompts: {} }, resolve));
   const matches = findPromptsByPrefix(data.prompts || {}, message.prefix);
   if (matches.length === 0) return { status: 'no_match' };
@@ -227,7 +255,7 @@ async function handlePromptTriggerLookup(message, sender) {
     if (exact) {
       // Exact match → inject prompt content.
       const r = await chrome.scripting.executeScript({
-        target: { tabId: sender.tab.id },
+        target: { tabId },
         world: 'MAIN',
         args: [exact.text, selectors],
         func: injectPromptIntoEditor,
@@ -241,7 +269,7 @@ async function handlePromptTriggerLookup(message, sender) {
       // Single match: autocomplete by updating line 1 to #fullName while keeping
       // the suggestion structure stable (no flash).
       const r = await chrome.scripting.executeScript({
-        target: { tabId: sender.tab.id },
+        target: { tabId },
         world: 'MAIN',
         args: [[matches[0].name], selectors, chrome.i18n.getMessage('appTitle'), '#' + matches[0].name],
         func: insertSuggestionsInEditor,
@@ -251,7 +279,7 @@ async function handlePromptTriggerLookup(message, sender) {
 
     // Ambiguous prefix → show all matches on next line, cursor stays on first line.
     const suggResults = await chrome.scripting.executeScript({
-      target: { tabId: sender.tab.id },
+      target: { tabId },
       world: 'MAIN',
       args: [matches.map(m => m.name), selectors, chrome.i18n.getMessage('appTitle')],
       func: insertSuggestionsInEditor,
@@ -265,6 +293,8 @@ async function handlePromptTriggerLookup(message, sender) {
 }
 
 async function handleSuggestUpdate(message, sender) {
+  const tabId = resolveTriggerTabId(sender);
+  if (tabId == null) return { status: 'cleared' };
   const data = await new Promise(resolve => loadData({ prompts: {} }, resolve));
   const selectors = GEMINI_EDITOR_SELECTORS;
   const names = message.prefix != null
@@ -272,7 +302,7 @@ async function handleSuggestUpdate(message, sender) {
     : [];
   try {
     await chrome.scripting.executeScript({
-      target: { tabId: sender.tab.id },
+      target: { tabId },
       world: 'MAIN',
       args: [names, selectors, chrome.i18n.getMessage('appTitle')],
       func: insertSuggestionsInEditor,
@@ -284,10 +314,12 @@ async function handleSuggestUpdate(message, sender) {
 }
 
 async function handleCycleTab(message, sender) {
+  const tabId = resolveTriggerTabId(sender);
+  if (tabId == null) return { status: 'error' };
   const selectors = GEMINI_EDITOR_SELECTORS;
   try {
     await chrome.scripting.executeScript({
-      target: { tabId: sender.tab.id },
+      target: { tabId },
       world: 'MAIN',
       args: [message.allNames, selectors, chrome.i18n.getMessage('appTitle'), '#' + message.name],
       func: insertSuggestionsInEditor,
@@ -299,6 +331,7 @@ async function handleCycleTab(message, sender) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!isTrustedSender(sender)) return false;
   if (message.action === 'promptTriggerLookup') {
     handlePromptTriggerLookup(message, sender)
       .then(sendResponse)

--- a/src/prompt-trigger.js
+++ b/src/prompt-trigger.js
@@ -91,9 +91,31 @@
     return parseSuggestionNames(fieldText(el));
   }
 
-  // --- Space: inject prompt or show suggestions ---
+  // SECURITY: only real user keystrokes may drive the trigger.
+  //
+  // This content script shares the DOM with the page, so page JS can call
+  // dispatchEvent() to forge these keys. Without this gate, script running on a
+  // supported AI site could synthesize "#" + Space, receive the whole prompt
+  // list (findPromptsByPrefix matches every prompt on an empty prefix), read the
+  // titles back out of the composer, then request each one by name and read its
+  // full body — the entire prompt library, with no user interaction. The
+  // background's site check cannot stop this: the attacker IS the supported site.
+  //
+  // isTrusted is the fix, and it is complete: dispatchEvent() can never produce
+  // an event with isTrusted true. Never remove this without a replacement.
+  function isRealUserEvent(e) {
+    return e.isTrusted === true;
+  }
 
-  document.addEventListener('keydown', async (e) => {
+  // --- Space: inject prompt or show suggestions ---
+  //
+  // The four handlers below are separated from their listeners so the isTrusted
+  // gate lives in exactly one place per listener and the behaviour underneath
+  // stays unit-testable: jsdom cannot manufacture a trusted event, so tests drive
+  // the handlers directly and assert separately that dispatching a synthetic
+  // event through the real listener does nothing.
+
+  async function onSpaceKeydown(e) {
     if (e.key !== ' ') return;
 
     const el = document.activeElement;
@@ -146,24 +168,35 @@
       insertSpace(el);
     }
     // 'injected' / 'autocompleted': background already acted on the editor.
-  }, true); // capture phase — fires before the editor's own handlers
+  }
+
+  // capture phase — fires before the editor's own handlers
+  document.addEventListener('keydown', (e) => {
+    if (!isRealUserEvent(e)) return;
+    return onSpaceKeydown(e);
+  }, true);
 
   // Suppress the Space keyup that follows a triggered injection. In Firefox the
   // service worker is slow enough that keyup fires before executeScript completes,
   // giving apps (e.g. Perplexity) time to convert the #word text into a chip token.
   // The flag is cleared here so only the immediate sibling keyup is suppressed.
   let _blockNextSpaceKeyup = false;
-  document.addEventListener('keyup', (e) => {
+  function onSpaceKeyup(e) {
     if (e.key === ' ' && _blockNextSpaceKeyup) {
       _blockNextSpaceKeyup = false;
       e.stopImmediatePropagation();
       e.preventDefault();
     }
+  }
+
+  document.addEventListener('keyup', (e) => {
+    if (!isRealUserEvent(e)) return;
+    onSpaceKeyup(e);
   }, true);
 
   // --- ArrowDown / ArrowUp: cycle through visible suggestions ---
 
-  document.addEventListener('keydown', (e) => {
+  function onArrowKeydown(e) {
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
 
     const el = document.activeElement;
@@ -197,11 +230,16 @@
     try {
       chrome.runtime.sendMessage({ action: 'promptTriggerCycleTab', name: nextName, allNames: names });
     } catch (_) {}
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (!isRealUserEvent(e)) return;
+    onArrowKeydown(e);
   }, true);
 
   // --- Live update of suggestion line as the user types ---
 
-  document.addEventListener('keyup', (e) => {
+  function onTypingKeyup(e) {
     if (e.key === ' ') return; // handled by keydown above
     // Only react to keys that actually change content.
     if (e.key.length !== 1 && e.key !== 'Backspace' && e.key !== 'Delete') return;
@@ -224,10 +262,21 @@
         await chrome.runtime.sendMessage({ action: 'promptTriggerSuggestUpdate', prefix });
       } catch (_) {}
     }, 80);
+  }
+
+  document.addEventListener('keyup', (e) => {
+    if (!isRealUserEvent(e)) return;
+    onTypingKeyup(e);
   }, true);
 
   // Exposed for unit tests (Node only; `module` is undefined in the content script).
+  // The handlers are exported because jsdom cannot produce a trusted event, so the
+  // behaviour tests call them directly; the isTrusted gate itself is covered by
+  // dispatching real synthetic events and asserting nothing happens.
   if (typeof module !== 'undefined') {
-    module.exports = { classifyTriggerField, parseSuggestionNames, SUGG_LINE_RE, LABEL_RE };
+    module.exports = {
+      classifyTriggerField, parseSuggestionNames, SUGG_LINE_RE, LABEL_RE,
+      onSpaceKeydown, onSpaceKeyup, onArrowKeydown, onTypingKeyup,
+    };
   }
 })();

--- a/tests/prompt-trigger-events.test.js
+++ b/tests/prompt-trigger-events.test.js
@@ -16,13 +16,29 @@ function focusedTextarea(value) {
   return ta;
 }
 
+// The listeners drop anything with isTrusted false, and jsdom cannot produce a
+// trusted event, so behaviour is driven through the exported handlers. The gate
+// itself is covered by the "synthetic events" block below, which dispatches real
+// events through the listeners and asserts nothing happens.
+const { onSpaceKeydown, onSpaceKeyup, onArrowKeydown, onTypingKeyup } = require('../src/prompt-trigger.js');
+
+const fakeEvent = (key) => ({
+  key,
+  preventDefault: jest.fn(),
+  stopImmediatePropagation: jest.fn(),
+});
+
 const press = (key) =>
-  document.getElementById('ta').dispatchEvent(
-    new KeyboardEvent('keydown', { key, bubbles: true })
-  );
+  (key === 'ArrowDown' || key === 'ArrowUp')
+    ? onArrowKeydown(fakeEvent(key))
+    : onSpaceKeydown(fakeEvent(key));
 const release = (key) =>
+  key === ' ' ? onSpaceKeyup(fakeEvent(key)) : onTypingKeyup(fakeEvent(key));
+
+// Real synthetic events, as hostile page JS would forge them.
+const dispatch = (type, key) =>
   document.getElementById('ta').dispatchEvent(
-    new KeyboardEvent('keyup', { key, bubbles: true })
+    new KeyboardEvent(type, { key, bubbles: true })
   );
 
 beforeEach(() => {
@@ -111,5 +127,56 @@ describe('Live suggestion update (debounced)', () => {
     release('e');
     jest.advanceTimersByTime(200);
     expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SECURITY: page-forged events must never reach the prompt library
+// ---------------------------------------------------------------------------
+
+describe('synthetic events are ignored (isTrusted gate)', () => {
+  afterEach(() => jest.useRealTimers());
+
+  // Without the gate, script on a supported AI site could forge these keys to
+  // enumerate every prompt title and then read each prompt's full body back out
+  // of the composer — the whole library, with no user interaction.
+  test('a forged Space on an injectable line asks for nothing', async () => {
+    focusedTextarea('#Review');
+    dispatch('keydown', ' ');
+    await flush();
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('a forged bare "#" cannot enumerate the whole library', async () => {
+    // An empty prefix matches every prompt (findPromptsByPrefix uses startsWith),
+    // which is what made this the cheapest possible exfiltration primitive.
+    focusedTextarea('#');
+    dispatch('keydown', ' ');
+    await flush();
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('forged arrow keys cannot cycle suggestions', () => {
+    focusedTextarea('#Review\n== Prompts ==\n#Review  #Refactor');
+    dispatch('keydown', 'ArrowDown');
+    dispatch('keydown', 'ArrowUp');
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('forged typing cannot drive live suggestions', () => {
+    jest.useFakeTimers();
+    focusedTextarea('#Rev');
+    dispatch('keyup', 'v');
+    jest.advanceTimersByTime(500);
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('a forged Space is not swallowed either — the page keeps its own event', () => {
+    // The suppression path must stay inert too, otherwise the gate would still
+    // let a page interfere with its own key handling through us.
+    focusedTextarea('#Review');
+    const e = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+    document.getElementById('ta').dispatchEvent(e);
+    expect(e.defaultPrevented).toBe(false);
   });
 });


### PR DESCRIPTION
Finding 1 of the external audit, verified against the code before fixing.

## The hole

`src/prompt-trigger.js` runs in the isolated world but **shares the DOM with the page**, and it never checked `event.isTrusted`. All four listeners accepted forged `KeyboardEvent`s.

That matters because of what sits behind them. `findPromptsByPrefix` uses `startsWith`, so **an empty prefix matches every prompt**. The background then writes the result into the page's **MAIN world**: titles via `insertSuggestionsInEditor`, full bodies via `injectPromptIntoEditor`.

So script executing on a supported AI site could, with **zero user interaction**:

1. focus a `contenteditable`, set it to `#`, dispatch a synthetic Space → the complete title list is written into the composer → read it back from the DOM;
2. for each title, repeat with `#Title` → the **full prompt body** is written into the composer → read it back;
3. exfiltrate the entire prompt library.

The background's `getSiteByUrl(sender.url)` check is no defence here: in this threat model **the attacker is the supported site**. Scope is therefore "compromised/malicious AI site → your saved prompts", not a universal drive-by — it needs script execution on an already-supported origin.

## The fix

`isRealUserEvent(e)` (`e.isTrusted === true`) at the top of all four listeners. `dispatchEvent()` can never set `isTrusted`, so this is a complete gate rather than a heuristic, and it costs nothing at runtime.

Defence in depth in **both** `background.js` (not shared, CLAUDE.md §6):

- `isTrustedSender` — rejects anything whose `sender.id` is not our own extension id, and anything we positively know is a subframe (`frameId != null && frameId !== 0`; some Firefox paths omit it, so a missing value is not treated as hostile).
- **Gemini Folders gains the origin check it never had** — it went straight from message to `loadData` to `executeScript`. AI Folders has had one since it grew past a single site.
- Tab resolution moves into `resolveTriggerTabId`. AF's `sender.tab?.id ?? tabs.query({active:true})` fallback exists for Firefox's dynamically registered local-LLM script, where `sender.tab` really is absent — so it stays, but now fires **only when the active tab is the same origin that spoke**. A background tab can no longer drive an injection into an unrelated foreground one. GF no longer dereferences `sender.tab.id` blind.

## Testing

jsdom cannot manufacture a trusted event, so the existing behaviour tests could not keep driving the listeners. The four handlers (`onSpaceKeydown`, `onSpaceKeyup`, `onArrowKeydown`, `onTypingKeyup`) are now named and exported: behaviour tests call them directly, and a new block dispatches **real synthetic events through the real listeners** and asserts nothing reaches the library — including the bare-`#` enumeration primitive, and that a forged Space is not swallowed either.

The guard stays in the listener, so there is no test seam in the security check itself.

**Verified non-vacuous:** with `isRealUserEvent` stubbed to `return true`, all five new tests fail; restored, they pass.

`npx jest` — 597 passing. `python build.py --yes` — clean; the three built scripts re-checked with `node --check`.

## Manual verification still owed (CLAUDE.md §5.4)

This touches the most fragile area in the project, so before merge I should re-test the `#` trigger and the ▶ button on several sites **and** a local LLM, in both extensions and both browsers — the Firefox local-LLM path especially, since that is the one relying on the origin-matched fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)