### PR TITLE
fix(privacy): move uninstall context into the URL fragment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,17 @@ the page only posts to a Google Form. **There is no database and no backend.**
   (not shared — fix bugs in both, §6). The URL carries `l` language, `v` version,
   `b` browser, `i` install date (`YYYY-MM-DD`), `ie=1` when that date was only
   inferred at update time, `o` popup opens and `s` conversations saved (both from
-  `usageStats`, `storage.local`). The *date* is sent, never a day count —
+  `usageStats`, `storage.local`), **all in the URL fragment (`#`), never the query
+  string**. The browser opens this page unprompted, so anything in the query would
+  already be in the request line — in the host's logs and leaked onward via
+  `Referer` — before the user consented. Fragments are never sent to a server,
+  which is exactly what makes `privacyBody`'s "Nothing leaves your device until you
+  press Send" literally true, and keeps `s1UninstallBody`'s "its address carries
+  six non-identifying details" true as well. **Never move these back to `?`.**
+  `docs/site/uninstall.js` reads the fragment and falls back to the query, because
+  `setUninstallURL` captured its value long before the page opens and an extension
+  that has not run since the switch still holds a `?` URL; drop the fallback once
+  that has aged out. The *date* is sent, never a day count —
   `setUninstallURL` is called long before the page opens, so a count would be
   stale; the page derives the tenure. The URL is re-signed on install/startup
   **and on every `usageStats` change**, so both counters stay current.

--- a/docs/site/uninstall.js
+++ b/docs/site/uninstall.js
@@ -90,7 +90,15 @@
 
   // --- URL context -----------------------------------------------------------
 
-  const params = new URLSearchParams(window.location.search);
+  // Read the fragment, not the query: the browser opens this page unprompted, so
+  // anything in the query string would have been transmitted to the host before
+  // the user consented to anything. Fragments never leave the browser.
+  // The query is still accepted as a fallback — setUninstallURL captures its value
+  // long before the page opens, so an extension that has not run since the switch
+  // still holds a '?' URL. Remove the fallback once that has aged out.
+  const params = new URLSearchParams(
+    window.location.hash.slice(1) || window.location.search
+  );
 
   // The extension already normalizes the tag ('pt-BR' → 'pt_BR'); this also
   // covers hand-typed URLs and direct visits with no param at all.

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -151,7 +151,8 @@ async function updateContextMenu() {
 // --- UNINSTALL FEEDBACK SURVEY ---
 // The browser opens this page when the user removes the extension. It carries
 // non-identifying context (tenure, version, browser, UI language, popup opens)
-// as URL params; nothing is transmitted unless the user submits the form there.
+// in the URL *fragment* — never the query, so opening the page transmits nothing;
+// only an explicit submit on the page sends anything. See buildUninstallUrl.
 // Page: docs/uninstall-ai-folders.html. Helper: buildUninstallUrl (utils.js).
 const UNINSTALL_SURVEY_URL = 'https://aifolders.xyz/uninstall-ai-folders.html';
 

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -78,7 +78,8 @@ function updateContextMenu() {
 // --- UNINSTALL FEEDBACK SURVEY ---
 // The browser opens this page when the user removes the extension. It carries
 // non-identifying context (tenure, version, browser, UI language, popup opens)
-// as URL params; nothing is transmitted unless the user submits the form there.
+// in the URL *fragment* — never the query, so opening the page transmits nothing;
+// only an explicit submit on the page sends anything. See buildUninstallUrl.
 // Page: docs/uninstall-gemini-folders.html. Helper: buildUninstallUrl (utils.js).
 const UNINSTALL_SURVEY_URL = 'https://aifolders.xyz/uninstall-gemini-folders.html';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -829,6 +829,15 @@ function normalizeUiLang(raw) {
 // before it is opened, so a precomputed count would be stale. The page derives
 // the tenure itself. Date is UTC day-precision — no timestamp, nothing that
 // could single out a user.
+//
+// PRIVACY: the values go in the URL *fragment*, never the query string. The
+// browser opens this page on its own when the extension is removed, so anything
+// in the query would already be in the request line — logged by the host, and
+// leaked onward via Referer — before the user had a say. Fragments are never
+// sent to the server, which is what makes the page's own promise ("nothing
+// leaves your device until you press Send") and the privacy policy's "its
+// address carries six non-identifying details" both literally true. Do not
+// "simplify" this back to '?'.
 function buildUninstallUrl(base, opts) {
   const o = opts || {};
   const p = new URLSearchParams();
@@ -846,7 +855,7 @@ function buildUninstallUrl(base, opts) {
   // four times and saved nothing" from "actually used it". saves === 0 means the
   // user never got the core action to work.
   p.set('s', String(Number(o.saves) || 0));
-  return base + '?' + p.toString();
+  return base + '#' + p.toString();
 }
 
 if (typeof module !== 'undefined') {

--- a/tests/uninstall-page.test.js
+++ b/tests/uninstall-page.test.js
@@ -4,12 +4,12 @@
  * params go in, and what comes out is the rendered form and — only on an
  * explicit submit — the Google Form payload.
  *
- * @jest-environment-options {"url": "https://aifolders.xyz/uninstall-ai-folders.html?l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9"}
+ * @jest-environment-options {"url": "https://aifolders.xyz/uninstall-ai-folders.html#l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9"}
  */
 
 // 2026-06-08 → 2026-07-25 is 47 days; pinned so the tenure math is assertable.
 const NOW = Date.UTC(2026, 6, 25, 12, 0, 0);
-const FR_URL = '/uninstall-ai-folders.html?l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9';
+const FR_URL = '/uninstall-ai-folders.html#l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9';
 
 // Stands in for real ids from a Form's pre-filled link.
 const WIRED = {
@@ -353,5 +353,51 @@ describe('submission', () => {
     global.fetch.mockClear();
     await submit();
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Where the context is read from
+// ---------------------------------------------------------------------------
+
+describe('URL context source', () => {
+  // The extension puts the context in the fragment so that opening this page —
+  // which the browser does unprompted, on removal — transmits nothing. The page
+  // must therefore read the fragment, and must keep reading the query for a
+  // while: setUninstallURL captured its value long before the page opens, so an
+  // extension that has not run since the switch still holds a '?' URL.
+  test('reads the context from the fragment', async () => {
+    load({ search: '/uninstall-ai-folders.html#l=en&i=2026-06-08&o=63&s=9&v=1.6.4&b=chrome' });
+    window.UF_FORMS = WIRED;
+    await submit();
+    expect(body().get('entry.4')).toBe('47');     // tenure derived from 'i'
+    expect(body().get('entry.6')).toBe('63');     // opens
+    expect(body().get('entry.10')).toBe('9');     // saves
+    expect(body().get('entry.7')).toBe('1.6.4');  // version
+  });
+
+  test('still reads a legacy query-string URL', async () => {
+    load({ search: '/uninstall-ai-folders.html?l=en&i=2026-06-08&o=63&s=9&v=1.6.4&b=chrome' });
+    window.UF_FORMS = WIRED;
+    await submit();
+    expect(body().get('entry.4')).toBe('47');
+    expect(body().get('entry.6')).toBe('63');
+    expect(body().get('entry.10')).toBe('9');
+  });
+
+  test('the fragment wins when both are present', async () => {
+    load({ search: '/uninstall-ai-folders.html?o=1&s=1#o=63&s=9&l=en' });
+    window.UF_FORMS = WIRED;
+    await submit();
+    expect(body().get('entry.6')).toBe('63');
+    expect(body().get('entry.10')).toBe('9');
+  });
+
+  test('a bare page with no context still renders and submits', async () => {
+    load({ search: '/uninstall-ai-folders.html' });
+    window.UF_FORMS = WIRED;
+    expect(opts().length).toBeGreaterThan(0);
+    await submit();
+    expect(body().has('entry.4')).toBe(false);
   });
 });

--- a/tests/uninstall-url.test.js
+++ b/tests/uninstall-url.test.js
@@ -6,6 +6,9 @@ const { buildUninstallUrl, normalizeUiLang } = require('../src/utils');
 
 const BASE = 'https://aifolders.xyz/uninstall-ai-folders.html';
 
+// The context rides in the fragment, so searchParams would always be empty here.
+const hashParams = (url) => new URLSearchParams(new URL(url).hash.slice(1));
+
 describe('normalizeUiLang', () => {
   // chrome.i18n.getUILanguage() returns BCP-47; the site's locale codes use '_'
   // and only pt/zh keep a region.
@@ -39,8 +42,8 @@ describe('buildUninstallUrl', () => {
       opens: 63,
       saves: 9,
     });
-    expect(url.startsWith(BASE + '?')).toBe(true);
-    const p = new URL(url).searchParams;
+    expect(url.startsWith(BASE + '#')).toBe(true);
+    const p = hashParams(url);
     expect(p.get('i')).toBe('2026-06-08');   // day precision, no timestamp
     expect(p.get('v')).toBe('1.6.2');
     expect(p.get('l')).toBe('pt_BR');
@@ -51,15 +54,15 @@ describe('buildUninstallUrl', () => {
   });
 
   test('an inferred install date is flagged, never passed off as exact', () => {
-    const p = new URL(buildUninstallUrl(BASE, {
+    const p = hashParams(buildUninstallUrl(BASE, {
       installedAt: Date.UTC(2026, 6, 25), estimated: true,
-    })).searchParams;
+    }));
     expect(p.get('i')).toBe('2026-07-25');
     expect(p.get('ie')).toBe('1');
   });
 
   test('an unknown install date is omitted rather than faked', () => {
-    const p = new URL(buildUninstallUrl(BASE, { version: '1.6.2' })).searchParams;
+    const p = hashParams(buildUninstallUrl(BASE, { version: '1.6.2' }));
     expect(p.has('i')).toBe(false);
     expect(p.has('ie')).toBe(false);
   });
@@ -67,10 +70,10 @@ describe('buildUninstallUrl', () => {
   // Zero is a finding, not a missing value: 'o=0' means the popup was never opened
   // and 's=0' that nothing was ever saved. Both must be sent explicitly.
   test('a fresh profile reports zero opens and zero saves instead of empty values', () => {
-    const fresh = new URL(buildUninstallUrl(BASE, {})).searchParams;
+    const fresh = hashParams(buildUninstallUrl(BASE, {}));
     expect(fresh.get('o')).toBe('0');
     expect(fresh.get('s')).toBe('0');
-    const undef = new URL(buildUninstallUrl(BASE, { opens: undefined, saves: undefined })).searchParams;
+    const undef = hashParams(buildUninstallUrl(BASE, { opens: undefined, saves: undefined }));
     expect(undef.get('o')).toBe('0');
     expect(undef.get('s')).toBe('0');
   });
@@ -82,7 +85,7 @@ describe('buildUninstallUrl', () => {
       // A caller passing extra state must not leak it into the URL.
       email: 'someone@example.com', folders: ['Work', 'Private'],
     });
-    const keys = Array.from(new URL(url).searchParams.keys()).sort();
+    const keys = Array.from(hashParams(url).keys()).sort();
     expect(keys).toEqual(['b', 'i', 'ie', 'l', 'o', 's', 'v']);
     expect(url).not.toContain('example.com');
     expect(url).not.toContain('Private');
@@ -91,7 +94,26 @@ describe('buildUninstallUrl', () => {
   test('values are URL-encoded, so a stray character cannot break the query', () => {
     const url = buildUninstallUrl(BASE, { version: '1.0 &beta=1', browser: 'chrome' });
     expect(url).not.toContain('&beta=1');
-    expect(new URL(url).searchParams.get('v')).toBe('1.0 &beta=1');
+    expect(hashParams(url).get('v')).toBe('1.0 &beta=1');
+  });
+
+  // The privacy guarantee itself. The browser opens this URL on its own when the
+  // extension is removed, so anything in the query string would already be in the
+  // request line — logged by the host, leaked onward via Referer — before the user
+  // agreed to anything. Fragments are never sent to a server, which is what makes
+  // the page's "nothing leaves your device until you press Send" literally true.
+  test('nothing is transmitted on load: the query string stays empty', () => {
+    const url = buildUninstallUrl(BASE, {
+      installedAt: Date.UTC(2026, 5, 8), version: '1.6.4', lang: 'fr',
+      browser: 'chrome', opens: 63, saves: 9,
+    });
+    const parsed = new URL(url);
+    expect(parsed.search).toBe('');
+    expect(Array.from(parsed.searchParams.keys())).toEqual([]);
+    // Everything before the '#' is the bare page address, nothing else.
+    expect(url.split('#')[0]).toBe(BASE);
+    // And the values really are present — in the half that never leaves the browser.
+    expect(hashParams(url).get('s')).toBe('9');
   });
 
   test('stays far under the 1023-char setUninstallURL limit', () => {


### PR DESCRIPTION
Finding 2 of the external audit. Stacked on #49.

## What was wrong

`buildUninstallUrl` built `base + '?' + params`. The browser opens that page **by itself** when the extension is removed, so all six values were in the HTTPS request line — in the static host's logs, and exposed onward via `Referer` — before the user had any say.

The page that displays *"Nothing leaves your device until you press Send"* had already sent them by the time it rendered that sentence.

**One correction to the audit:** it claims the privacy policy is contradicted too. It isn't. `s1UninstallBody` says *"Its address carries six non-identifying details"* and enumerates all six — an accurate description of exactly this mechanism. Only the on-page `privacyBody` string was false.

## The fix

`base + '#' + params`. Fragments are never sent to a server.

This is the cheap fix precisely because it makes both existing strings true rather than requiring new ones:

- *"Nothing leaves your device until you press Send"* — now literally true.
- *"Its address carries six non-identifying details"* — still true; a fragment is part of the address.

So **none of the 43 translations of either string changes.** It also puts the generated Firefox manifest's `data_collection_permissions: {required: ["none"]}` (`build.py:249`) on solid ground: nothing is collected automatically any more, which is a question an AMO reviewer could fairly have asked before.

## Backward compatibility

`docs/site/uninstall.js` reads the fragment and **still accepts the query**. `setUninstallURL` captures its value long before the page opens, so an extension that has not run since this ships still holds a `?` URL — and that user's uninstall must not land on a blank page. The fallback can be dropped once that has aged out; noted in the code and in CLAUDE.md §9.

## Testing

- The page suite now runs on the **fragment** form by default (the URL and `FR_URL` fixtures), so all 26 existing tests exercise the new path.
- New `URL context source` block: fragment read, legacy query still read, fragment wins when both are present, and a bare URL with no context still renders and submits.
- The URL suite asserts the guarantee itself: `new URL(url).search === ''`, no `searchParams` keys, and everything before the `#` is exactly the page address.

`npx jest` — 602 passing. `python build.py --yes` — clean.

## Manual verification owed

Uninstall a locally loaded build and watch the request: the URL opened must contain no `?`, and the page must render in the right language with the right tenure. Then hand-craft an old `?` URL to confirm the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)