### PR TITLE
fix(storage): confirm the write before deleting what it replaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,17 @@ the page only posts to a Google Form. **There is no database and no backend.**
   (not shared — fix bugs in both, §6). The URL carries `l` language, `v` version,
   `b` browser, `i` install date (`YYYY-MM-DD`), `ie=1` when that date was only
   inferred at update time, `o` popup opens and `s` conversations saved (both from
-  `usageStats`, `storage.local`). The *date* is sent, never a day count —
+  `usageStats`, `storage.local`), **all in the URL fragment (`#`), never the query
+  string**. The browser opens this page unprompted, so anything in the query would
+  already be in the request line — in the host's logs and leaked onward via
+  `Referer` — before the user consented. Fragments are never sent to a server,
+  which is exactly what makes `privacyBody`'s "Nothing leaves your device until you
+  press Send" literally true, and keeps `s1UninstallBody`'s "its address carries
+  six non-identifying details" true as well. **Never move these back to `?`.**
+  `docs/site/uninstall.js` reads the fragment and falls back to the query, because
+  `setUninstallURL` captured its value long before the page opens and an extension
+  that has not run since the switch still holds a `?` URL; drop the fallback once
+  that has aged out. The *date* is sent, never a day count —
   `setUninstallURL` is called long before the page opens, so a count would be
   stale; the page derives the tenure. The URL is re-signed on install/startup
   **and on every `usageStats` change**, so both counters stay current.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,23 @@ git checkout main && git pull --ff-only
 
 - **Storage:** `loadData`/`saveData` (utils.js) transparently compress (LZString)
   and chunk content across `storage.sync` (quota ~100 KB total, 8 KB per item;
-  `makeChunks`/`assembleChunks`). UI open-state (`openFolders`/`openPrompts`) lives
+  `makeChunks`/`assembleChunks`).
+  **Write first, delete second — never the reverse.** The chunks and their
+  `fdcN`/`pdcN` pointer go out in a *single* `sync.set`, whose quota Chrome
+  evaluates as a unit, so that call is the commit point. Every superseded key is
+  removed in `runCleanup()`, only after that set confirms. Doing the removes first
+  (as the code did until 2026-08) loses data on a failed write: the shrink case
+  deletes the tail chunks, the set fails, the surviving pointer references keys
+  that are gone, `assembleChunks` returns garbage, and `loadData` silently falls
+  back to `{}` — every folder appears empty. **Do not "fix" this with generation-
+  prefixed chunks:** two generations coexisting doubles peak usage against a
+  *shared* 100 KB ceiling, so anyone above ~50 % would stop being able to save at
+  all — a worse regression than the bug, for a guarantee the single set already
+  gives. Errors must reach the caller: `saveData` passes a message for both sync
+  *and* local failures, `mergeImportData` rejects, and both `background.js` use
+  `saveDataAsync`/`saveOrReportError` so a failed quick-save shows
+  `storageFullError` instead of "✅ Saved!" (a service worker has no `window`, so
+  the modal fallback never fires there). UI open-state (`openFolders`/`openPrompts`) lives
   in `storage.local` — device-local, to avoid burning the sync write quota.
   `finishSave(..., affectsBookmarks)` only rebuilds the bookmark mirror when
   folders/pins/sort actually change. Default sort is `dateDesc` (newest-first) for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,20 @@ git checkout main && git pull --ff-only
   via `chrome.scripting.executeScript({ world: 'MAIN', func: ... })`. The injected
   prompt text comes from the user's own storage, gated by `getSiteByUrl(sender.url)`
   — a page cannot drive it (no `externally_connectable`).
+  **Every listener starts with `isRealUserEvent(e)` (`e.isTrusted === true`) and that
+  is load-bearing security, not hygiene.** The content script shares the DOM with the
+  page, so script on a supported site could otherwise forge `#` + Space, get the whole
+  prompt list back (an empty prefix matches everything), read the titles out of the
+  composer, then request each body — the entire library, no user interaction. The
+  site check cannot help: the attacker *is* the supported site. `dispatchEvent` can
+  never set `isTrusted`, so the gate is complete. jsdom cannot make a trusted event
+  either, which is why the four handlers (`onSpaceKeydown` etc.) are exported and
+  tested directly while `tests/prompt-trigger-events.test.js` dispatches real
+  synthetic events to prove the gate holds. Behind it, both `background.js` add
+  `isTrustedSender` (own extension id, main frame only) and resolve the target tab
+  via `resolveTriggerTabId` — AF's active-tab fallback for Firefox's dynamically
+  registered local-LLM script only fires when the active tab is the **same origin**
+  that spoke, so a background tab can never drive an injection into another one.
 - **Title extraction:** `extractTitleLogic` + per-site strategies in
   `site-config.js`, run via `executeScript`. Falls back to a heuristic (lowest
   sizeable text field) and logs `console.warn("[Folders extension] …")` when a

--- a/docs/site/uninstall.js
+++ b/docs/site/uninstall.js
@@ -90,7 +90,15 @@
 
   // --- URL context -----------------------------------------------------------
 
-  const params = new URLSearchParams(window.location.search);
+  // Read the fragment, not the query: the browser opens this page unprompted, so
+  // anything in the query string would have been transmitted to the host before
+  // the user consented to anything. Fragments never leave the browser.
+  // The query is still accepted as a fallback — setUninstallURL captures its value
+  // long before the page opens, so an extension that has not run since the switch
+  // still holds a '?' URL. Remove the fallback once that has aged out.
+  const params = new URLSearchParams(
+    window.location.hash.slice(1) || window.location.search
+  );
 
   // The extension already normalizes the tag ('pt-BR' → 'pt_BR'); this also
   // covers hand-typed URLs and direct visits with no param at all.

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -249,6 +249,36 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
 
 // --- PROMPT TRIGGER (#prefix + Space → bash-like autocomplete/injection) ---
 
+// Defence in depth behind prompt-trigger.js's isTrusted gate. These handlers read
+// the user's prompt library and write it into the page's MAIN world, so they must
+// only ever answer our own content script running in a top-level document.
+// Not a substitute for the isTrusted check: the origin is the attacker's own in
+// that threat model. This only narrows who can reach the handler at all.
+function isTrustedSender(sender) {
+  if (!sender || sender.id !== chrome.runtime.id) return false;
+  // frameId is 0 for the main frame. Reject only when we positively know it is a
+  // subframe — some Firefox paths omit it, and none of these flows target iframes.
+  if (sender.frameId != null && sender.frameId !== 0) return false;
+  return true;
+}
+
+// The tab to inject into. sender.tab may be absent for dynamically-registered
+// content scripts in Firefox (the local-LLM path), hence the active-tab fallback —
+// but only when the active tab is the same origin that spoke, so a background tab
+// can never drive an injection into an unrelated one.
+async function resolveTriggerTabId(sender) {
+  if (sender.tab?.id != null) return sender.tab.id;
+  if (!sender.url) return null;
+  const [active] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!active?.url) return null;
+  try {
+    if (new URL(active.url).origin !== new URL(sender.url).origin) return null;
+  } catch (_) {
+    return null;
+  }
+  return active.id;
+}
+
 async function handlePromptTriggerLookup(message, sender) {
   const { localLlmUrl } = await chrome.storage.sync.get(['localLlmUrl']);
   // sender.tab may be absent for dynamically-registered content scripts in Firefox;
@@ -273,9 +303,7 @@ async function handlePromptTriggerLookup(message, sender) {
   // suggestions only — injection itself still goes through unchanged.
   const noSuggestions = forceClear || !!SITES[siteKey]?.noSuggestions;
 
-  // sender.tab may be absent for dynamically-registered scripts in Firefox;
-  // fall back to the active tab in the current window.
-  const tabId = sender.tab?.id ?? (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id;
+  const tabId = await resolveTriggerTabId(sender);
   if (!tabId) return { status: 'no_match' };
 
   try {
@@ -344,7 +372,7 @@ async function handleSuggestUpdate(message, sender) {
   const names = message.prefix != null
     ? findPromptsByPrefix(data.prompts || {}, message.prefix).map(m => m.name)
     : [];
-  const tabId = sender.tab?.id ?? (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id;
+  const tabId = await resolveTriggerTabId(sender);
   if (!tabId) return { status: 'cleared' };
   try {
     await chrome.scripting.executeScript({
@@ -367,7 +395,7 @@ async function handleCycleTab(message, sender) {
   if (!selectors) return { status: 'error' };
   // No suggestion block is ever shown on these sites, so there is nothing to cycle.
   if (SITES[siteKey]?.forceClear || SITES[siteKey]?.noSuggestions) return { status: 'error' };
-  const tabId = sender.tab?.id ?? (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id;
+  const tabId = await resolveTriggerTabId(sender);
   if (!tabId) return { status: 'error' };
   try {
     await chrome.scripting.executeScript({
@@ -383,6 +411,7 @@ async function handleCycleTab(message, sender) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!isTrustedSender(sender)) return false;
   if (message.action === 'promptTriggerLookup') {
     handlePromptTriggerLookup(message, sender)
       .then(sendResponse)

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -434,6 +434,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return false;
 });
 
+// Saves and returns the error instead of throwing, so a failed write shows a
+// failure toast rather than "✅ Saved!". The old `new Promise(r => saveData(d, r))`
+// resolved *with* the error and dropped it; there is no window in a service
+// worker either, so utils.js's modal fallback never fires here.
+async function saveOrReportError(dataToSave) {
+  try {
+    await saveDataAsync(dataToSave);
+    return null;
+  } catch (err) {
+    console.error("Save failed:", err);
+    return err;
+  }
+}
+
 // --- TOAST ---
 
 const showToast = (msg, bgColor) => {
@@ -483,10 +497,12 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       const chatEntry = { title: finalTitle, url: tab.url, timestamp: Date.now() };
       if (siteKey) chatEntry.site = siteKey;
       folders[targetFolder].push(chatEntry);
-      await new Promise(resolve => saveData({ folders }, resolve));
+      const saveError = await saveOrReportError({ folders });
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        args: [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", siteColor],
+        args: saveError
+          ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+          : [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", siteColor],
         func: showToast
       });
     } else {
@@ -540,11 +556,13 @@ chrome.commands.onCommand.addListener(async (command) => {
       const chatEntry = { title: finalTitle, url: tab.url, timestamp: Date.now() };
       if (siteKey) chatEntry.site = siteKey;
       folders[targetFolder].push(chatEntry);
-      await new Promise(resolve => saveData({ folders }, resolve));
+      const saveError = await saveOrReportError({ folders });
 
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        args: [toastMsg, siteColor],
+        args: saveError
+          ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+          : [toastMsg, siteColor],
         func: showToast
       });
     } else {

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -151,7 +151,8 @@ async function updateContextMenu() {
 // --- UNINSTALL FEEDBACK SURVEY ---
 // The browser opens this page when the user removes the extension. It carries
 // non-identifying context (tenure, version, browser, UI language, popup opens)
-// as URL params; nothing is transmitted unless the user submits the form there.
+// in the URL *fragment* — never the query, so opening the page transmits nothing;
+// only an explicit submit on the page sends anything. See buildUninstallUrl.
 // Page: docs/uninstall-ai-folders.html. Helper: buildUninstallUrl (utils.js).
 const UNINSTALL_SURVEY_URL = 'https://aifolders.xyz/uninstall-ai-folders.html';
 

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -215,7 +215,35 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
 // --- PROMPT TRIGGER (#prefix + Space → bash-like autocomplete/injection) ---
 
+// Defence in depth behind prompt-trigger.js's isTrusted gate. These handlers read
+// the user's prompt library and write it into the page's MAIN world, so they must
+// only ever answer our own content script running in a top-level Gemini document.
+// The manifest already scopes the content script to gemini.google.com; this makes
+// that guarantee explicit here rather than relying on it from a distance (AF has
+// carried the equivalent check since it gained multiple sites).
+function isTrustedSender(sender) {
+  if (!sender || sender.id !== chrome.runtime.id) return false;
+  // frameId is 0 for the main frame. Reject only when we positively know it is a
+  // subframe — some Firefox paths omit it, and none of these flows target iframes.
+  if (sender.frameId != null && sender.frameId !== 0) return false;
+  const url = sender.tab?.url ?? sender.url;
+  try {
+    if (new URL(url).hostname !== 'gemini.google.com') return false;
+  } catch (_) {
+    return false;
+  }
+  return true;
+}
+
+// sender.tab is present for manifest-declared content scripts; guard anyway so a
+// missing tab yields a clean no-op instead of a TypeError swallowed by try/catch.
+function resolveTriggerTabId(sender) {
+  return sender.tab?.id ?? null;
+}
+
 async function handlePromptTriggerLookup(message, sender) {
+  const tabId = resolveTriggerTabId(sender);
+  if (tabId == null) return { status: 'no_match' };
   const data = await new Promise(resolve => loadData({ prompts: {} }, resolve));
   const matches = findPromptsByPrefix(data.prompts || {}, message.prefix);
   if (matches.length === 0) return { status: 'no_match' };
@@ -227,7 +255,7 @@ async function handlePromptTriggerLookup(message, sender) {
     if (exact) {
       // Exact match → inject prompt content.
       const r = await chrome.scripting.executeScript({
-        target: { tabId: sender.tab.id },
+        target: { tabId },
         world: 'MAIN',
         args: [exact.text, selectors],
         func: injectPromptIntoEditor,
@@ -241,7 +269,7 @@ async function handlePromptTriggerLookup(message, sender) {
       // Single match: autocomplete by updating line 1 to #fullName while keeping
       // the suggestion structure stable (no flash).
       const r = await chrome.scripting.executeScript({
-        target: { tabId: sender.tab.id },
+        target: { tabId },
         world: 'MAIN',
         args: [[matches[0].name], selectors, chrome.i18n.getMessage('appTitle'), '#' + matches[0].name],
         func: insertSuggestionsInEditor,
@@ -251,7 +279,7 @@ async function handlePromptTriggerLookup(message, sender) {
 
     // Ambiguous prefix → show all matches on next line, cursor stays on first line.
     const suggResults = await chrome.scripting.executeScript({
-      target: { tabId: sender.tab.id },
+      target: { tabId },
       world: 'MAIN',
       args: [matches.map(m => m.name), selectors, chrome.i18n.getMessage('appTitle')],
       func: insertSuggestionsInEditor,
@@ -265,6 +293,8 @@ async function handlePromptTriggerLookup(message, sender) {
 }
 
 async function handleSuggestUpdate(message, sender) {
+  const tabId = resolveTriggerTabId(sender);
+  if (tabId == null) return { status: 'cleared' };
   const data = await new Promise(resolve => loadData({ prompts: {} }, resolve));
   const selectors = GEMINI_EDITOR_SELECTORS;
   const names = message.prefix != null
@@ -272,7 +302,7 @@ async function handleSuggestUpdate(message, sender) {
     : [];
   try {
     await chrome.scripting.executeScript({
-      target: { tabId: sender.tab.id },
+      target: { tabId },
       world: 'MAIN',
       args: [names, selectors, chrome.i18n.getMessage('appTitle')],
       func: insertSuggestionsInEditor,
@@ -284,10 +314,12 @@ async function handleSuggestUpdate(message, sender) {
 }
 
 async function handleCycleTab(message, sender) {
+  const tabId = resolveTriggerTabId(sender);
+  if (tabId == null) return { status: 'error' };
   const selectors = GEMINI_EDITOR_SELECTORS;
   try {
     await chrome.scripting.executeScript({
-      target: { tabId: sender.tab.id },
+      target: { tabId },
       world: 'MAIN',
       args: [message.allNames, selectors, chrome.i18n.getMessage('appTitle'), '#' + message.name],
       func: insertSuggestionsInEditor,
@@ -299,6 +331,7 @@ async function handleCycleTab(message, sender) {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!isTrustedSender(sender)) return false;
   if (message.action === 'promptTriggerLookup') {
     handlePromptTriggerLookup(message, sender)
       .then(sendResponse)

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -78,7 +78,8 @@ function updateContextMenu() {
 // --- UNINSTALL FEEDBACK SURVEY ---
 // The browser opens this page when the user removes the extension. It carries
 // non-identifying context (tenure, version, browser, UI language, popup opens)
-// as URL params; nothing is transmitted unless the user submits the form there.
+// in the URL *fragment* — never the query, so opening the page transmits nothing;
+// only an explicit submit on the page sends anything. See buildUninstallUrl.
 // Page: docs/uninstall-gemini-folders.html. Helper: buildUninstallUrl (utils.js).
 const UNINSTALL_SURVEY_URL = 'https://aifolders.xyz/uninstall-gemini-folders.html';
 

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -148,6 +148,20 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
   }
 });
 
+// Saves and returns the error instead of throwing, so a failed write shows a
+// failure toast rather than "✅ Saved!". The old `new Promise(r => saveData(d, r))`
+// resolved *with* the error and dropped it; there is no window in a service
+// worker either, so utils.js's modal fallback never fires here.
+async function saveOrReportError(dataToSave) {
+  try {
+    await saveDataAsync(dataToSave);
+    return null;
+  } catch (err) {
+    console.error("Save failed:", err);
+    return err;
+  }
+}
+
 // Injected into the active Gemini tab to show a transient confirmation toast.
 // Text color follows the background's luminance (same helper as AI Folders).
 function showToast(msg, bgColor) {
@@ -193,11 +207,13 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
           timestamp: Date.now()
         });
 
-        await new Promise(resolve => saveData({ folders: folders }, resolve));
+        const saveError = await saveOrReportError({ folders: folders });
 
         await chrome.scripting.executeScript({
           target: { tabId: tab.id },
-          args: [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", "#1a73e8"],
+          args: saveError
+            ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+            : [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", "#1a73e8"],
           func: showToast
         });
       } else {
@@ -398,12 +414,13 @@ chrome.commands.onCommand.addListener(async (command) => {
           timestamp: Date.now()
         });
 
-        await new Promise(resolve => saveData({ folders: folders }, resolve));
+        const saveError = await saveOrReportError({ folders: folders });
 
-        // SUCCESS
         await chrome.scripting.executeScript({
           target: { tabId: tab.id },
-          args: [toastMsg, "#1a73e8"],
+          args: saveError
+            ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+            : [toastMsg, "#1a73e8"],
           func: showToast
         });
       } else {

--- a/src/prompt-trigger.js
+++ b/src/prompt-trigger.js
@@ -91,9 +91,31 @@
     return parseSuggestionNames(fieldText(el));
   }
 
-  // --- Space: inject prompt or show suggestions ---
+  // SECURITY: only real user keystrokes may drive the trigger.
+  //
+  // This content script shares the DOM with the page, so page JS can call
+  // dispatchEvent() to forge these keys. Without this gate, script running on a
+  // supported AI site could synthesize "#" + Space, receive the whole prompt
+  // list (findPromptsByPrefix matches every prompt on an empty prefix), read the
+  // titles back out of the composer, then request each one by name and read its
+  // full body — the entire prompt library, with no user interaction. The
+  // background's site check cannot stop this: the attacker IS the supported site.
+  //
+  // isTrusted is the fix, and it is complete: dispatchEvent() can never produce
+  // an event with isTrusted true. Never remove this without a replacement.
+  function isRealUserEvent(e) {
+    return e.isTrusted === true;
+  }
 
-  document.addEventListener('keydown', async (e) => {
+  // --- Space: inject prompt or show suggestions ---
+  //
+  // The four handlers below are separated from their listeners so the isTrusted
+  // gate lives in exactly one place per listener and the behaviour underneath
+  // stays unit-testable: jsdom cannot manufacture a trusted event, so tests drive
+  // the handlers directly and assert separately that dispatching a synthetic
+  // event through the real listener does nothing.
+
+  async function onSpaceKeydown(e) {
     if (e.key !== ' ') return;
 
     const el = document.activeElement;
@@ -146,24 +168,35 @@
       insertSpace(el);
     }
     // 'injected' / 'autocompleted': background already acted on the editor.
-  }, true); // capture phase — fires before the editor's own handlers
+  }
+
+  // capture phase — fires before the editor's own handlers
+  document.addEventListener('keydown', (e) => {
+    if (!isRealUserEvent(e)) return;
+    return onSpaceKeydown(e);
+  }, true);
 
   // Suppress the Space keyup that follows a triggered injection. In Firefox the
   // service worker is slow enough that keyup fires before executeScript completes,
   // giving apps (e.g. Perplexity) time to convert the #word text into a chip token.
   // The flag is cleared here so only the immediate sibling keyup is suppressed.
   let _blockNextSpaceKeyup = false;
-  document.addEventListener('keyup', (e) => {
+  function onSpaceKeyup(e) {
     if (e.key === ' ' && _blockNextSpaceKeyup) {
       _blockNextSpaceKeyup = false;
       e.stopImmediatePropagation();
       e.preventDefault();
     }
+  }
+
+  document.addEventListener('keyup', (e) => {
+    if (!isRealUserEvent(e)) return;
+    onSpaceKeyup(e);
   }, true);
 
   // --- ArrowDown / ArrowUp: cycle through visible suggestions ---
 
-  document.addEventListener('keydown', (e) => {
+  function onArrowKeydown(e) {
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
 
     const el = document.activeElement;
@@ -197,11 +230,16 @@
     try {
       chrome.runtime.sendMessage({ action: 'promptTriggerCycleTab', name: nextName, allNames: names });
     } catch (_) {}
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (!isRealUserEvent(e)) return;
+    onArrowKeydown(e);
   }, true);
 
   // --- Live update of suggestion line as the user types ---
 
-  document.addEventListener('keyup', (e) => {
+  function onTypingKeyup(e) {
     if (e.key === ' ') return; // handled by keydown above
     // Only react to keys that actually change content.
     if (e.key.length !== 1 && e.key !== 'Backspace' && e.key !== 'Delete') return;
@@ -224,10 +262,21 @@
         await chrome.runtime.sendMessage({ action: 'promptTriggerSuggestUpdate', prefix });
       } catch (_) {}
     }, 80);
+  }
+
+  document.addEventListener('keyup', (e) => {
+    if (!isRealUserEvent(e)) return;
+    onTypingKeyup(e);
   }, true);
 
   // Exposed for unit tests (Node only; `module` is undefined in the content script).
+  // The handlers are exported because jsdom cannot produce a trusted event, so the
+  // behaviour tests call them directly; the isTrusted gate itself is covered by
+  // dispatching real synthetic events and asserting nothing happens.
   if (typeof module !== 'undefined') {
-    module.exports = { classifyTriggerField, parseSuggestionNames, SUGG_LINE_RE, LABEL_RE };
+    module.exports = {
+      classifyTriggerField, parseSuggestionNames, SUGG_LINE_RE, LABEL_RE,
+      onSpaceKeydown, onSpaceKeyup, onArrowKeydown, onTypingKeyup,
+    };
   }
 })();

--- a/src/utils.js
+++ b/src/utils.js
@@ -160,8 +160,9 @@ function saveData(dataToSave, callback) {
     const syncToSet = {};
     const syncToRemove = [];
     const localToSet = {};
-    // Local keys to remove ONLY after sync.set confirms success, to prevent data loss on failure.
-    const localCleanupAfterSync = [];
+    // Keys superseded by this save. NOTHING here is deleted until every write has
+    // been confirmed — see runCleanup below.
+    const localToRemove = [];
 
     // Pass through non-data keys (sortPref, pinnedFolders, etc.) to sync as-is,
     // except the device-local UI-state keys which go to storage.local.
@@ -199,15 +200,15 @@ function saveData(dataToSave, callback) {
     if (dataToSave.prompts) {
       const compressed = LZString.compressToUTF16(JSON.stringify(dataToSave.prompts));
       syncToRemove.push('prompts');
-      chrome.storage.local.remove(['prompts']);
+      localToRemove.push('prompts');
 
       if (isPromptsSyncEnabled) {
         Object.assign(syncToSet, makeChunks(compressed, 'pdc'));
         const newN = syncToSet.pdcN;
         for (let i = newN; i < (syncState.pdcN || 0); i++) syncToRemove.push('pdc' + i);
         syncToRemove.push('promptsDataCompressed'); // remove legacy sync key
-        // Defer local cleanup: only delete local copy after sync confirms success.
-        localCleanupAfterSync.push('promptsDataCompressed');
+        // The local copy is the only remaining backup until sync confirms.
+        localToRemove.push('promptsDataCompressed');
       } else {
         localToSet.promptsDataCompressed = compressed;
         const oldSyncPdcN = syncState.pdcN || 0;
@@ -216,24 +217,41 @@ function saveData(dataToSave, callback) {
       }
     }
 
-    // Fire-and-forget removes (Chrome queues ops, so these land before the subsequent set).
-    if (syncToRemove.length > 0) chrome.storage.sync.remove(syncToRemove);
+    // Delete the superseded keys only once the replacement has actually landed.
+    //
+    // These removes used to fire here, before the set, on the assumption that
+    // Chrome queues operations in order. That holds — but ordering was never the
+    // problem: if the set then FAILS (quota, write-rate), the old chunks are
+    // already gone while the surviving fdcN still points at them. assembleChunks
+    // concatenates the missing keys as '', LZString fails to decompress, and
+    // loadData silently falls back to {} — every folder appears empty. The same
+    // reasoning already governed the local copy of prompts moving to sync; it
+    // simply was never applied to the sync side.
+    //
+    // Safe to fire-and-forget once we are here: a failed cleanup only leaves a
+    // stale chunk behind, and assembleChunks reads 0..N-1, so it is never seen.
+    const runCleanup = () => {
+      if (syncToRemove.length > 0) chrome.storage.sync.remove(syncToRemove);
+      if (localToRemove.length > 0) chrome.storage.local.remove(localToRemove);
+    };
 
     const doSyncSave = () => {
       // Nothing to write to sync (e.g. a local-only UI-state save like expanding
       // a folder) — skip the sync.set so it no longer counts against the quota.
       if (Object.keys(syncToSet).length === 0) {
+        runCleanup();
         finishSave(callback, null, isContentSave, affectsBookmarks);
         return;
       }
+      // The new chunks AND their fdcN/pdcN pointer go out in this one set, whose
+      // quota check Chrome evaluates as a unit — so this call is the commit point.
       chrome.storage.sync.set(syncToSet, () => {
         if (chrome.runtime.lastError) {
-          // Local data was NOT deleted (deferred cleanup never ran) — report error to caller.
+          // Nothing was deleted, so the previous state is still intact and readable.
           if (callback) callback(chrome.runtime.lastError.message || 'Storage error');
           return;
         }
-        // Sync succeeded — now safe to remove the local backup of prompts that moved to sync.
-        if (localCleanupAfterSync.length > 0) chrome.storage.local.remove(localCleanupAfterSync);
+        runCleanup();
         finishSave(callback, null, isContentSave, affectsBookmarks);
       });
     };
@@ -246,7 +264,10 @@ function saveData(dataToSave, callback) {
           if (typeof window !== 'undefined' && window.showCustomModal) {
             window.showCustomModal({ title: localErrMsg, type: 'alert' });
           } else { console.warn(localErrMsg); }
-          if (callback) callback();
+          // Report the failure: callers check `err` to decide between a success
+          // message and an error one, so calling back empty made a failed write
+          // look like a successful save.
+          if (callback) callback(localErrMsg);
           return;
         }
         doSyncSave();
@@ -254,6 +275,18 @@ function saveData(dataToSave, callback) {
     } else {
       doSyncSave();
     }
+  });
+}
+
+// Promise wrapper around saveData that REJECTS on a storage failure. Both
+// background.js used `new Promise(resolve => saveData(data, resolve))`, which
+// resolves *with* the error string and then discards it — so a quota-failed
+// quick-save still showed "✅ Saved!". There is no window in a service worker
+// either, so utils.js's modal fallback never fires there: the write failed
+// completely silently. Use this instead of hand-rolling the wrapper.
+function saveDataAsync(dataToSave) {
+  return new Promise((resolve, reject) => {
+    saveData(dataToSave, (err) => (err ? reject(new Error(err)) : resolve()));
   });
 }
 
@@ -474,9 +507,13 @@ function mergeImportData(importedData) {
         }
       }
 
-      // Final save
-      saveData({ folders: currentFolders, pinnedFolders: currentPinned, prompts: currentPrompts }, () => {
-        resolve();
+      // Final save. Reject on a storage failure instead of resolving blindly:
+      // an import that hit the quota was reporting "Import successful!" while
+      // nothing had been written — the worst possible moment to be wrong, since
+      // the user is likely restoring a backup after losing data.
+      saveData({ folders: currentFolders, pinnedFolders: currentPinned, prompts: currentPrompts }, (err) => {
+        if (err) reject(new Error(err));
+        else resolve();
       });
     });
   });
@@ -879,5 +916,6 @@ if (typeof module !== 'undefined') {
     insertSuggestionsInEditor,
     normalizeUiLang,
     buildUninstallUrl,
+    saveDataAsync,
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -829,6 +829,15 @@ function normalizeUiLang(raw) {
 // before it is opened, so a precomputed count would be stale. The page derives
 // the tenure itself. Date is UTC day-precision — no timestamp, nothing that
 // could single out a user.
+//
+// PRIVACY: the values go in the URL *fragment*, never the query string. The
+// browser opens this page on its own when the extension is removed, so anything
+// in the query would already be in the request line — logged by the host, and
+// leaked onward via Referer — before the user had a say. Fragments are never
+// sent to the server, which is what makes the page's own promise ("nothing
+// leaves your device until you press Send") and the privacy policy's "its
+// address carries six non-identifying details" both literally true. Do not
+// "simplify" this back to '?'.
 function buildUninstallUrl(base, opts) {
   const o = opts || {};
   const p = new URLSearchParams();
@@ -846,7 +855,7 @@ function buildUninstallUrl(base, opts) {
   // four times and saved nothing" from "actually used it". saves === 0 means the
   // user never got the core action to work.
   p.set('s', String(Number(o.saves) || 0));
-  return base + '?' + p.toString();
+  return base + '#' + p.toString();
 }
 
 if (typeof module !== 'undefined') {

--- a/tests/prompt-trigger-events.test.js
+++ b/tests/prompt-trigger-events.test.js
@@ -16,13 +16,29 @@ function focusedTextarea(value) {
   return ta;
 }
 
+// The listeners drop anything with isTrusted false, and jsdom cannot produce a
+// trusted event, so behaviour is driven through the exported handlers. The gate
+// itself is covered by the "synthetic events" block below, which dispatches real
+// events through the listeners and asserts nothing happens.
+const { onSpaceKeydown, onSpaceKeyup, onArrowKeydown, onTypingKeyup } = require('../src/prompt-trigger.js');
+
+const fakeEvent = (key) => ({
+  key,
+  preventDefault: jest.fn(),
+  stopImmediatePropagation: jest.fn(),
+});
+
 const press = (key) =>
-  document.getElementById('ta').dispatchEvent(
-    new KeyboardEvent('keydown', { key, bubbles: true })
-  );
+  (key === 'ArrowDown' || key === 'ArrowUp')
+    ? onArrowKeydown(fakeEvent(key))
+    : onSpaceKeydown(fakeEvent(key));
 const release = (key) =>
+  key === ' ' ? onSpaceKeyup(fakeEvent(key)) : onTypingKeyup(fakeEvent(key));
+
+// Real synthetic events, as hostile page JS would forge them.
+const dispatch = (type, key) =>
   document.getElementById('ta').dispatchEvent(
-    new KeyboardEvent('keyup', { key, bubbles: true })
+    new KeyboardEvent(type, { key, bubbles: true })
   );
 
 beforeEach(() => {
@@ -111,5 +127,56 @@ describe('Live suggestion update (debounced)', () => {
     release('e');
     jest.advanceTimersByTime(200);
     expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SECURITY: page-forged events must never reach the prompt library
+// ---------------------------------------------------------------------------
+
+describe('synthetic events are ignored (isTrusted gate)', () => {
+  afterEach(() => jest.useRealTimers());
+
+  // Without the gate, script on a supported AI site could forge these keys to
+  // enumerate every prompt title and then read each prompt's full body back out
+  // of the composer — the whole library, with no user interaction.
+  test('a forged Space on an injectable line asks for nothing', async () => {
+    focusedTextarea('#Review');
+    dispatch('keydown', ' ');
+    await flush();
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('a forged bare "#" cannot enumerate the whole library', async () => {
+    // An empty prefix matches every prompt (findPromptsByPrefix uses startsWith),
+    // which is what made this the cheapest possible exfiltration primitive.
+    focusedTextarea('#');
+    dispatch('keydown', ' ');
+    await flush();
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('forged arrow keys cannot cycle suggestions', () => {
+    focusedTextarea('#Review\n== Prompts ==\n#Review  #Refactor');
+    dispatch('keydown', 'ArrowDown');
+    dispatch('keydown', 'ArrowUp');
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('forged typing cannot drive live suggestions', () => {
+    jest.useFakeTimers();
+    focusedTextarea('#Rev');
+    dispatch('keyup', 'v');
+    jest.advanceTimersByTime(500);
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('a forged Space is not swallowed either — the page keeps its own event', () => {
+    // The suppression path must stay inert too, otherwise the gate would still
+    // let a page interfere with its own key handling through us.
+    focusedTextarea('#Review');
+    const e = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+    document.getElementById('ta').dispatchEvent(e);
+    expect(e.defaultPrevented).toBe(false);
   });
 });

--- a/tests/uninstall-page.test.js
+++ b/tests/uninstall-page.test.js
@@ -4,12 +4,12 @@
  * params go in, and what comes out is the rendered form and — only on an
  * explicit submit — the Google Form payload.
  *
- * @jest-environment-options {"url": "https://aifolders.xyz/uninstall-ai-folders.html?l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9"}
+ * @jest-environment-options {"url": "https://aifolders.xyz/uninstall-ai-folders.html#l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9"}
  */
 
 // 2026-06-08 → 2026-07-25 is 47 days; pinned so the tenure math is assertable.
 const NOW = Date.UTC(2026, 6, 25, 12, 0, 0);
-const FR_URL = '/uninstall-ai-folders.html?l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9';
+const FR_URL = '/uninstall-ai-folders.html#l=fr&v=1.6.2&b=chrome&i=2026-06-08&o=63&s=9';
 
 // Stands in for real ids from a Form's pre-filled link.
 const WIRED = {
@@ -353,5 +353,51 @@ describe('submission', () => {
     global.fetch.mockClear();
     await submit();
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Where the context is read from
+// ---------------------------------------------------------------------------
+
+describe('URL context source', () => {
+  // The extension puts the context in the fragment so that opening this page —
+  // which the browser does unprompted, on removal — transmits nothing. The page
+  // must therefore read the fragment, and must keep reading the query for a
+  // while: setUninstallURL captured its value long before the page opens, so an
+  // extension that has not run since the switch still holds a '?' URL.
+  test('reads the context from the fragment', async () => {
+    load({ search: '/uninstall-ai-folders.html#l=en&i=2026-06-08&o=63&s=9&v=1.6.4&b=chrome' });
+    window.UF_FORMS = WIRED;
+    await submit();
+    expect(body().get('entry.4')).toBe('47');     // tenure derived from 'i'
+    expect(body().get('entry.6')).toBe('63');     // opens
+    expect(body().get('entry.10')).toBe('9');     // saves
+    expect(body().get('entry.7')).toBe('1.6.4');  // version
+  });
+
+  test('still reads a legacy query-string URL', async () => {
+    load({ search: '/uninstall-ai-folders.html?l=en&i=2026-06-08&o=63&s=9&v=1.6.4&b=chrome' });
+    window.UF_FORMS = WIRED;
+    await submit();
+    expect(body().get('entry.4')).toBe('47');
+    expect(body().get('entry.6')).toBe('63');
+    expect(body().get('entry.10')).toBe('9');
+  });
+
+  test('the fragment wins when both are present', async () => {
+    load({ search: '/uninstall-ai-folders.html?o=1&s=1#o=63&s=9&l=en' });
+    window.UF_FORMS = WIRED;
+    await submit();
+    expect(body().get('entry.6')).toBe('63');
+    expect(body().get('entry.10')).toBe('9');
+  });
+
+  test('a bare page with no context still renders and submits', async () => {
+    load({ search: '/uninstall-ai-folders.html' });
+    window.UF_FORMS = WIRED;
+    expect(opts().length).toBeGreaterThan(0);
+    await submit();
+    expect(body().has('entry.4')).toBe(false);
   });
 });

--- a/tests/uninstall-url.test.js
+++ b/tests/uninstall-url.test.js
@@ -6,6 +6,9 @@ const { buildUninstallUrl, normalizeUiLang } = require('../src/utils');
 
 const BASE = 'https://aifolders.xyz/uninstall-ai-folders.html';
 
+// The context rides in the fragment, so searchParams would always be empty here.
+const hashParams = (url) => new URLSearchParams(new URL(url).hash.slice(1));
+
 describe('normalizeUiLang', () => {
   // chrome.i18n.getUILanguage() returns BCP-47; the site's locale codes use '_'
   // and only pt/zh keep a region.
@@ -39,8 +42,8 @@ describe('buildUninstallUrl', () => {
       opens: 63,
       saves: 9,
     });
-    expect(url.startsWith(BASE + '?')).toBe(true);
-    const p = new URL(url).searchParams;
+    expect(url.startsWith(BASE + '#')).toBe(true);
+    const p = hashParams(url);
     expect(p.get('i')).toBe('2026-06-08');   // day precision, no timestamp
     expect(p.get('v')).toBe('1.6.2');
     expect(p.get('l')).toBe('pt_BR');
@@ -51,15 +54,15 @@ describe('buildUninstallUrl', () => {
   });
 
   test('an inferred install date is flagged, never passed off as exact', () => {
-    const p = new URL(buildUninstallUrl(BASE, {
+    const p = hashParams(buildUninstallUrl(BASE, {
       installedAt: Date.UTC(2026, 6, 25), estimated: true,
-    })).searchParams;
+    }));
     expect(p.get('i')).toBe('2026-07-25');
     expect(p.get('ie')).toBe('1');
   });
 
   test('an unknown install date is omitted rather than faked', () => {
-    const p = new URL(buildUninstallUrl(BASE, { version: '1.6.2' })).searchParams;
+    const p = hashParams(buildUninstallUrl(BASE, { version: '1.6.2' }));
     expect(p.has('i')).toBe(false);
     expect(p.has('ie')).toBe(false);
   });
@@ -67,10 +70,10 @@ describe('buildUninstallUrl', () => {
   // Zero is a finding, not a missing value: 'o=0' means the popup was never opened
   // and 's=0' that nothing was ever saved. Both must be sent explicitly.
   test('a fresh profile reports zero opens and zero saves instead of empty values', () => {
-    const fresh = new URL(buildUninstallUrl(BASE, {})).searchParams;
+    const fresh = hashParams(buildUninstallUrl(BASE, {}));
     expect(fresh.get('o')).toBe('0');
     expect(fresh.get('s')).toBe('0');
-    const undef = new URL(buildUninstallUrl(BASE, { opens: undefined, saves: undefined })).searchParams;
+    const undef = hashParams(buildUninstallUrl(BASE, { opens: undefined, saves: undefined }));
     expect(undef.get('o')).toBe('0');
     expect(undef.get('s')).toBe('0');
   });
@@ -82,7 +85,7 @@ describe('buildUninstallUrl', () => {
       // A caller passing extra state must not leak it into the URL.
       email: 'someone@example.com', folders: ['Work', 'Private'],
     });
-    const keys = Array.from(new URL(url).searchParams.keys()).sort();
+    const keys = Array.from(hashParams(url).keys()).sort();
     expect(keys).toEqual(['b', 'i', 'ie', 'l', 'o', 's', 'v']);
     expect(url).not.toContain('example.com');
     expect(url).not.toContain('Private');
@@ -91,7 +94,26 @@ describe('buildUninstallUrl', () => {
   test('values are URL-encoded, so a stray character cannot break the query', () => {
     const url = buildUninstallUrl(BASE, { version: '1.0 &beta=1', browser: 'chrome' });
     expect(url).not.toContain('&beta=1');
-    expect(new URL(url).searchParams.get('v')).toBe('1.0 &beta=1');
+    expect(hashParams(url).get('v')).toBe('1.0 &beta=1');
+  });
+
+  // The privacy guarantee itself. The browser opens this URL on its own when the
+  // extension is removed, so anything in the query string would already be in the
+  // request line — logged by the host, leaked onward via Referer — before the user
+  // agreed to anything. Fragments are never sent to a server, which is what makes
+  // the page's "nothing leaves your device until you press Send" literally true.
+  test('nothing is transmitted on load: the query string stays empty', () => {
+    const url = buildUninstallUrl(BASE, {
+      installedAt: Date.UTC(2026, 5, 8), version: '1.6.4', lang: 'fr',
+      browser: 'chrome', opens: 63, saves: 9,
+    });
+    const parsed = new URL(url);
+    expect(parsed.search).toBe('');
+    expect(Array.from(parsed.searchParams.keys())).toEqual([]);
+    // Everything before the '#' is the bare page address, nothing else.
+    expect(url.split('#')[0]).toBe(BASE);
+    // And the values really are present — in the half that never leaves the browser.
+    expect(hashParams(url).get('s')).toBe('9');
   });
 
   test('stays far under the 1023-char setUninstallURL limit', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -351,6 +351,75 @@ describe('saveData', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Write-before-delete: nothing is removed until the replacement has landed
+  // -------------------------------------------------------------------------
+
+  test("removes the superseded keys only AFTER the write is confirmed", (done) => {
+    const order = [];
+    chrome.storage.sync.remove.mockImplementation(() => order.push("remove"));
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => { order.push("set"); cb(); });
+
+    saveData({ folders: { Dev: [] } }, () => {
+      expect(order).toEqual(["set", "remove"]);
+      done();
+    });
+  });
+
+  test("deletes nothing when the write fails, so the old data stays readable", (done) => {
+    // The failure that used to destroy data: the shrink case removed the tail
+    // chunks first, the set then failed, and the surviving fdcN pointed at keys
+    // that no longer existed -> assembleChunks returned garbage -> loadData fell
+    // back to {} and every folder looked empty.
+    chrome.storage.sync.get.mockImplementation((keys, cb) =>
+      cb({ syncBookmarksEnabled: false, fdcN: 5 }));
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: "QUOTA_BYTES quota exceeded" };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+
+    saveData({ folders: { Dev: [] } }, (err) => {
+      expect(err).toBe("QUOTA_BYTES quota exceeded");
+      expect(chrome.storage.sync.remove).not.toHaveBeenCalled();
+      expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  test("reports a local write failure instead of calling back empty", (done) => {
+    // callback() with no argument made every caller take its success branch.
+    chrome.storage.local.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: "QUOTA_BYTES quota exceeded" };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+
+    saveData({ openFolders: ["Dev"] }, (err) => {
+      expect(err).toBeTruthy();
+      expect(String(err)).toContain("QUOTA_BYTES");
+      done();
+    });
+  });
+
+  test("keeps the local prompts backup when the sync write fails", (done) => {
+    // Prompts moving to sync: the local copy is the only remaining backup until
+    // sync confirms, so a failed sync must not take it with it.
+    chrome.storage.sync.get.mockImplementation((keys, cb) =>
+      cb({ syncBookmarksEnabled: false, syncPromptsEnabled: true }));
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: "QUOTA_BYTES quota exceeded" };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+
+    saveData({ prompts: { P1: { text: "t", timestamp: 1 } } }, (err) => {
+      expect(err).toBeTruthy();
+      expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
   // finishSave only reads the bookmark settings (the gate before a full-tree
   // rebuild) when the write can actually change the mirrored tree. We assert on
   // that read instead of on syncToBookmarksTree so the test stays free of the
@@ -492,6 +561,21 @@ describe('mergeImportData', () => {
     const syncArg = calls[calls.length - 1]?.[0];
     // pinnedFolders is stored uncompressed in sync
     expect(syncArg?.pinnedFolders ?? []).toContain('Dev');
+  });
+
+  test('rejects when the merged data cannot actually be saved', async () => {
+    // An import that hit the quota used to resolve, so both callers announced
+    // "Import successful!" while nothing had been written — the worst possible
+    // moment to be wrong, since the user is usually restoring a lost backup.
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: 'QUOTA_BYTES quota exceeded' };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+    const importedData = {
+      folders: { Dev: [{ title: 'Chat', url: 'https://gemini.google.com/app/x', timestamp: 1 }] },
+    };
+    await expect(mergeImportData(importedData)).rejects.toThrow(/QUOTA_BYTES/);
   });
 
   test('rejects array input', async () => {


### PR DESCRIPTION
Finding 3 of the external audit. Stacked on #50.

## The data-loss window

`saveData` removed the superseded sync chunks — and the legacy `foldersDataCompressed` / `folders` backup keys — **before** issuing the set that replaced them, fire-and-forget.

Ordering was never the problem; Chrome does queue the operations. The problem is a **failed** set: the old chunks are already gone while the surviving `fdcN` still points at them. `assembleChunks` concatenates the missing keys as `''`, LZString fails to decompress, and `loadData` silently falls back to `{}` — **every folder appears empty**. The shrink case (this save needs fewer chunks than the last) is the one that actually destroyed data.

Notably the function *already knew* this: `localCleanupAfterSync` deferred the local prompts copy until sync confirmed, with a comment explaining exactly why. The reasoning was simply never applied to the sync side.

## Why not generation-prefixed chunks

The plan originally called for full atomicity via generations. I checked the numbers first and it would have been a net regression:

- The chunks **and** their `fdcN`/`pdcN` pointer already go out in **one `sync.set`**, whose quota Chrome evaluates as a unit. That call is already an all-or-nothing commit point.
- Two generations coexisting doubles peak occupancy against a **shared 102 400-byte** ceiling. The extension ships a storage bar precisely because users approach it. Anyone above ~50 % would stop being able to save at all — worse than the bug, and it needs a data migration.

So the fix is to move the deletes into `runCleanup()`, called only after the set confirms. Same guarantee, zero quota cost, no migration. Written into CLAUDE.md §7 so nobody reaches for generations later.

## Errors now reach the caller

- **Local write failure** passed `callback()` with no argument, so every caller took its `if (err)`-free success branch. It now passes the message.
- **`mergeImportData`** ignored its `err` and always resolved — "Import successful!" over a quota-failed restore, at the exact moment the user is most likely recovering lost data. It now rejects; both callers already `catch`, so they surface it with no change.
- **All four background quick-saves** used `new Promise(r => saveData(d, r))`, which resolves *with* the error and drops it, then showed "✅ Saved!" regardless. They now use the shared `saveDataAsync` via `saveOrReportError` and show the existing `storageFullError` string (already in all 43 locales — no new key). This mattered most here: a service worker has no `window`, so utils.js's modal fallback never fired and these failures were completely silent.

What the audit understates: the **sync** error path was already correct and plumbed through ~9 popup callers via `storageFullError`. The gaps were precisely local, import, and background.

## Testing

Five new tests, each **verified to fail without its fix**:

- remove happens after set, not before (asserted on call order);
- nothing is deleted at all when the set fails — the case that used to empty every folder;
- a local write failure is reported rather than called back empty;
- the local prompts backup survives a failed sync (it is the only remaining copy);
- an import that cannot be saved rejects instead of announcing success.

`npx jest` — 607 passing. `python build.py --yes` — clean; both built background scripts re-checked with `node --check`.

## Manual verification owed

Fill sync storage near the quota, force a failure, and confirm the folders are **still there** after reopening the popup — that is the whole point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)