### PR TITLE
fix(storage): confirm the write before deleting what it replaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,23 @@ git checkout main && git pull --ff-only
 
 - **Storage:** `loadData`/`saveData` (utils.js) transparently compress (LZString)
   and chunk content across `storage.sync` (quota ~100 KB total, 8 KB per item;
-  `makeChunks`/`assembleChunks`). UI open-state (`openFolders`/`openPrompts`) lives
+  `makeChunks`/`assembleChunks`).
+  **Write first, delete second — never the reverse.** The chunks and their
+  `fdcN`/`pdcN` pointer go out in a *single* `sync.set`, whose quota Chrome
+  evaluates as a unit, so that call is the commit point. Every superseded key is
+  removed in `runCleanup()`, only after that set confirms. Doing the removes first
+  (as the code did until 2026-08) loses data on a failed write: the shrink case
+  deletes the tail chunks, the set fails, the surviving pointer references keys
+  that are gone, `assembleChunks` returns garbage, and `loadData` silently falls
+  back to `{}` — every folder appears empty. **Do not "fix" this with generation-
+  prefixed chunks:** two generations coexisting doubles peak usage against a
+  *shared* 100 KB ceiling, so anyone above ~50 % would stop being able to save at
+  all — a worse regression than the bug, for a guarantee the single set already
+  gives. Errors must reach the caller: `saveData` passes a message for both sync
+  *and* local failures, `mergeImportData` rejects, and both `background.js` use
+  `saveDataAsync`/`saveOrReportError` so a failed quick-save shows
+  `storageFullError` instead of "✅ Saved!" (a service worker has no `window`, so
+  the modal fallback never fires there). UI open-state (`openFolders`/`openPrompts`) lives
   in `storage.local` — device-local, to avoid burning the sync write quota.
   `finishSave(..., affectsBookmarks)` only rebuilds the bookmark mirror when
   folders/pins/sort actually change. Default sort is `dateDesc` (newest-first) for

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -434,6 +434,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return false;
 });
 
+// Saves and returns the error instead of throwing, so a failed write shows a
+// failure toast rather than "✅ Saved!". The old `new Promise(r => saveData(d, r))`
+// resolved *with* the error and dropped it; there is no window in a service
+// worker either, so utils.js's modal fallback never fires here.
+async function saveOrReportError(dataToSave) {
+  try {
+    await saveDataAsync(dataToSave);
+    return null;
+  } catch (err) {
+    console.error("Save failed:", err);
+    return err;
+  }
+}
+
 // --- TOAST ---
 
 const showToast = (msg, bgColor) => {
@@ -483,10 +497,12 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       const chatEntry = { title: finalTitle, url: tab.url, timestamp: Date.now() };
       if (siteKey) chatEntry.site = siteKey;
       folders[targetFolder].push(chatEntry);
-      await new Promise(resolve => saveData({ folders }, resolve));
+      const saveError = await saveOrReportError({ folders });
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        args: [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", siteColor],
+        args: saveError
+          ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+          : [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", siteColor],
         func: showToast
       });
     } else {
@@ -540,11 +556,13 @@ chrome.commands.onCommand.addListener(async (command) => {
       const chatEntry = { title: finalTitle, url: tab.url, timestamp: Date.now() };
       if (siteKey) chatEntry.site = siteKey;
       folders[targetFolder].push(chatEntry);
-      await new Promise(resolve => saveData({ folders }, resolve));
+      const saveError = await saveOrReportError({ folders });
 
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        args: [toastMsg, siteColor],
+        args: saveError
+          ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+          : [toastMsg, siteColor],
         func: showToast
       });
     } else {

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -148,6 +148,20 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
   }
 });
 
+// Saves and returns the error instead of throwing, so a failed write shows a
+// failure toast rather than "✅ Saved!". The old `new Promise(r => saveData(d, r))`
+// resolved *with* the error and dropped it; there is no window in a service
+// worker either, so utils.js's modal fallback never fires here.
+async function saveOrReportError(dataToSave) {
+  try {
+    await saveDataAsync(dataToSave);
+    return null;
+  } catch (err) {
+    console.error("Save failed:", err);
+    return err;
+  }
+}
+
 // Injected into the active Gemini tab to show a transient confirmation toast.
 // Text color follows the background's luminance (same helper as AI Folders).
 function showToast(msg, bgColor) {
@@ -193,11 +207,13 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
           timestamp: Date.now()
         });
 
-        await new Promise(resolve => saveData({ folders: folders }, resolve));
+        const saveError = await saveOrReportError({ folders: folders });
 
         await chrome.scripting.executeScript({
           target: { tabId: tab.id },
-          args: [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", "#1a73e8"],
+          args: saveError
+            ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+            : [chrome.i18n.getMessage("toastSaved") || "✅ Saved!", "#1a73e8"],
           func: showToast
         });
       } else {
@@ -398,12 +414,13 @@ chrome.commands.onCommand.addListener(async (command) => {
           timestamp: Date.now()
         });
 
-        await new Promise(resolve => saveData({ folders: folders }, resolve));
+        const saveError = await saveOrReportError({ folders: folders });
 
-        // SUCCESS
         await chrome.scripting.executeScript({
           target: { tabId: tab.id },
-          args: [toastMsg, "#1a73e8"],
+          args: saveError
+            ? [chrome.i18n.getMessage("storageFullError") || "⚠️ Storage full — not saved.", "#d93025"]
+            : [toastMsg, "#1a73e8"],
           func: showToast
         });
       } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -160,8 +160,9 @@ function saveData(dataToSave, callback) {
     const syncToSet = {};
     const syncToRemove = [];
     const localToSet = {};
-    // Local keys to remove ONLY after sync.set confirms success, to prevent data loss on failure.
-    const localCleanupAfterSync = [];
+    // Keys superseded by this save. NOTHING here is deleted until every write has
+    // been confirmed — see runCleanup below.
+    const localToRemove = [];
 
     // Pass through non-data keys (sortPref, pinnedFolders, etc.) to sync as-is,
     // except the device-local UI-state keys which go to storage.local.
@@ -199,15 +200,15 @@ function saveData(dataToSave, callback) {
     if (dataToSave.prompts) {
       const compressed = LZString.compressToUTF16(JSON.stringify(dataToSave.prompts));
       syncToRemove.push('prompts');
-      chrome.storage.local.remove(['prompts']);
+      localToRemove.push('prompts');
 
       if (isPromptsSyncEnabled) {
         Object.assign(syncToSet, makeChunks(compressed, 'pdc'));
         const newN = syncToSet.pdcN;
         for (let i = newN; i < (syncState.pdcN || 0); i++) syncToRemove.push('pdc' + i);
         syncToRemove.push('promptsDataCompressed'); // remove legacy sync key
-        // Defer local cleanup: only delete local copy after sync confirms success.
-        localCleanupAfterSync.push('promptsDataCompressed');
+        // The local copy is the only remaining backup until sync confirms.
+        localToRemove.push('promptsDataCompressed');
       } else {
         localToSet.promptsDataCompressed = compressed;
         const oldSyncPdcN = syncState.pdcN || 0;
@@ -216,24 +217,41 @@ function saveData(dataToSave, callback) {
       }
     }
 
-    // Fire-and-forget removes (Chrome queues ops, so these land before the subsequent set).
-    if (syncToRemove.length > 0) chrome.storage.sync.remove(syncToRemove);
+    // Delete the superseded keys only once the replacement has actually landed.
+    //
+    // These removes used to fire here, before the set, on the assumption that
+    // Chrome queues operations in order. That holds — but ordering was never the
+    // problem: if the set then FAILS (quota, write-rate), the old chunks are
+    // already gone while the surviving fdcN still points at them. assembleChunks
+    // concatenates the missing keys as '', LZString fails to decompress, and
+    // loadData silently falls back to {} — every folder appears empty. The same
+    // reasoning already governed the local copy of prompts moving to sync; it
+    // simply was never applied to the sync side.
+    //
+    // Safe to fire-and-forget once we are here: a failed cleanup only leaves a
+    // stale chunk behind, and assembleChunks reads 0..N-1, so it is never seen.
+    const runCleanup = () => {
+      if (syncToRemove.length > 0) chrome.storage.sync.remove(syncToRemove);
+      if (localToRemove.length > 0) chrome.storage.local.remove(localToRemove);
+    };
 
     const doSyncSave = () => {
       // Nothing to write to sync (e.g. a local-only UI-state save like expanding
       // a folder) — skip the sync.set so it no longer counts against the quota.
       if (Object.keys(syncToSet).length === 0) {
+        runCleanup();
         finishSave(callback, null, isContentSave, affectsBookmarks);
         return;
       }
+      // The new chunks AND their fdcN/pdcN pointer go out in this one set, whose
+      // quota check Chrome evaluates as a unit — so this call is the commit point.
       chrome.storage.sync.set(syncToSet, () => {
         if (chrome.runtime.lastError) {
-          // Local data was NOT deleted (deferred cleanup never ran) — report error to caller.
+          // Nothing was deleted, so the previous state is still intact and readable.
           if (callback) callback(chrome.runtime.lastError.message || 'Storage error');
           return;
         }
-        // Sync succeeded — now safe to remove the local backup of prompts that moved to sync.
-        if (localCleanupAfterSync.length > 0) chrome.storage.local.remove(localCleanupAfterSync);
+        runCleanup();
         finishSave(callback, null, isContentSave, affectsBookmarks);
       });
     };
@@ -246,7 +264,10 @@ function saveData(dataToSave, callback) {
           if (typeof window !== 'undefined' && window.showCustomModal) {
             window.showCustomModal({ title: localErrMsg, type: 'alert' });
           } else { console.warn(localErrMsg); }
-          if (callback) callback();
+          // Report the failure: callers check `err` to decide between a success
+          // message and an error one, so calling back empty made a failed write
+          // look like a successful save.
+          if (callback) callback(localErrMsg);
           return;
         }
         doSyncSave();
@@ -254,6 +275,18 @@ function saveData(dataToSave, callback) {
     } else {
       doSyncSave();
     }
+  });
+}
+
+// Promise wrapper around saveData that REJECTS on a storage failure. Both
+// background.js used `new Promise(resolve => saveData(data, resolve))`, which
+// resolves *with* the error string and then discards it — so a quota-failed
+// quick-save still showed "✅ Saved!". There is no window in a service worker
+// either, so utils.js's modal fallback never fires there: the write failed
+// completely silently. Use this instead of hand-rolling the wrapper.
+function saveDataAsync(dataToSave) {
+  return new Promise((resolve, reject) => {
+    saveData(dataToSave, (err) => (err ? reject(new Error(err)) : resolve()));
   });
 }
 
@@ -474,9 +507,13 @@ function mergeImportData(importedData) {
         }
       }
 
-      // Final save
-      saveData({ folders: currentFolders, pinnedFolders: currentPinned, prompts: currentPrompts }, () => {
-        resolve();
+      // Final save. Reject on a storage failure instead of resolving blindly:
+      // an import that hit the quota was reporting "Import successful!" while
+      // nothing had been written — the worst possible moment to be wrong, since
+      // the user is likely restoring a backup after losing data.
+      saveData({ folders: currentFolders, pinnedFolders: currentPinned, prompts: currentPrompts }, (err) => {
+        if (err) reject(new Error(err));
+        else resolve();
       });
     });
   });
@@ -879,5 +916,6 @@ if (typeof module !== 'undefined') {
     insertSuggestionsInEditor,
     normalizeUiLang,
     buildUninstallUrl,
+    saveDataAsync,
   };
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -351,6 +351,75 @@ describe('saveData', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Write-before-delete: nothing is removed until the replacement has landed
+  // -------------------------------------------------------------------------
+
+  test("removes the superseded keys only AFTER the write is confirmed", (done) => {
+    const order = [];
+    chrome.storage.sync.remove.mockImplementation(() => order.push("remove"));
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => { order.push("set"); cb(); });
+
+    saveData({ folders: { Dev: [] } }, () => {
+      expect(order).toEqual(["set", "remove"]);
+      done();
+    });
+  });
+
+  test("deletes nothing when the write fails, so the old data stays readable", (done) => {
+    // The failure that used to destroy data: the shrink case removed the tail
+    // chunks first, the set then failed, and the surviving fdcN pointed at keys
+    // that no longer existed -> assembleChunks returned garbage -> loadData fell
+    // back to {} and every folder looked empty.
+    chrome.storage.sync.get.mockImplementation((keys, cb) =>
+      cb({ syncBookmarksEnabled: false, fdcN: 5 }));
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: "QUOTA_BYTES quota exceeded" };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+
+    saveData({ folders: { Dev: [] } }, (err) => {
+      expect(err).toBe("QUOTA_BYTES quota exceeded");
+      expect(chrome.storage.sync.remove).not.toHaveBeenCalled();
+      expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  test("reports a local write failure instead of calling back empty", (done) => {
+    // callback() with no argument made every caller take its success branch.
+    chrome.storage.local.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: "QUOTA_BYTES quota exceeded" };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+
+    saveData({ openFolders: ["Dev"] }, (err) => {
+      expect(err).toBeTruthy();
+      expect(String(err)).toContain("QUOTA_BYTES");
+      done();
+    });
+  });
+
+  test("keeps the local prompts backup when the sync write fails", (done) => {
+    // Prompts moving to sync: the local copy is the only remaining backup until
+    // sync confirms, so a failed sync must not take it with it.
+    chrome.storage.sync.get.mockImplementation((keys, cb) =>
+      cb({ syncBookmarksEnabled: false, syncPromptsEnabled: true }));
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: "QUOTA_BYTES quota exceeded" };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+
+    saveData({ prompts: { P1: { text: "t", timestamp: 1 } } }, (err) => {
+      expect(err).toBeTruthy();
+      expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
   // finishSave only reads the bookmark settings (the gate before a full-tree
   // rebuild) when the write can actually change the mirrored tree. We assert on
   // that read instead of on syncToBookmarksTree so the test stays free of the
@@ -492,6 +561,21 @@ describe('mergeImportData', () => {
     const syncArg = calls[calls.length - 1]?.[0];
     // pinnedFolders is stored uncompressed in sync
     expect(syncArg?.pinnedFolders ?? []).toContain('Dev');
+  });
+
+  test('rejects when the merged data cannot actually be saved', async () => {
+    // An import that hit the quota used to resolve, so both callers announced
+    // "Import successful!" while nothing had been written — the worst possible
+    // moment to be wrong, since the user is usually restoring a lost backup.
+    chrome.storage.sync.set.mockImplementationOnce((_, cb) => {
+      chrome.runtime.lastError = { message: 'QUOTA_BYTES quota exceeded' };
+      cb();
+      chrome.runtime.lastError = null;
+    });
+    const importedData = {
+      folders: { Dev: [{ title: 'Chat', url: 'https://gemini.google.com/app/x', timestamp: 1 }] },
+    };
+    await expect(mergeImportData(importedData)).rejects.toThrow(/QUOTA_BYTES/);
   });
 
   test('rejects array input', async () => {


### PR DESCRIPTION
Finding 3 of the external audit. (Recreated from #51, auto-closed when its stacked base branch was deleted.)

## The data-loss window

`saveData` removed the superseded sync chunks — and the legacy `foldersDataCompressed` / `folders` backup keys — **before** issuing the set that replaced them, fire-and-forget.

Ordering was never the problem; Chrome does queue the operations. The problem is a **failed** set: the old chunks are already gone while the surviving `fdcN` still points at them. `assembleChunks` concatenates the missing keys as `''`, LZString fails to decompress, and `loadData` silently falls back to `{}` — **every folder appears empty**. The shrink case (this save needs fewer chunks than the last) is the one that actually destroyed data.

Notably the function *already knew* this: `localCleanupAfterSync` deferred the local prompts copy until sync confirmed, with a comment explaining exactly why. The reasoning was simply never applied to the sync side.

## Why not generation-prefixed chunks

The plan originally called for full atomicity via generations. The numbers made it a net regression:

- The chunks **and** their `fdcN`/`pdcN` pointer already go out in **one `sync.set`**, whose quota Chrome evaluates as a unit. That call is already an all-or-nothing commit point.
- Two generations coexisting doubles peak occupancy against a **shared 102 400-byte** ceiling. The extension ships a storage bar precisely because users approach it. Anyone above ~50 % would stop being able to save at all — worse than the bug, and it needs a data migration.

So the fix moves the deletes into `runCleanup()`, called only after the set confirms. Same guarantee, zero quota cost, no migration. Written into CLAUDE.md §7 so nobody reaches for generations later.

## Errors now reach the caller

- **Local write failure** passed `callback()` with no argument, so every caller took its success branch. It now passes the message.
- **`mergeImportData`** ignored its `err` and always resolved — "Import successful!" over a quota-failed restore, at the exact moment the user is most likely recovering lost data. It now rejects; both callers already `catch`, so they surface it with no change.
- **All four background quick-saves** used `new Promise(r => saveData(d, r))`, which resolves *with* the error and drops it, then showed "✅ Saved!" regardless. They now use the shared `saveDataAsync` via `saveOrReportError` and show the existing `storageFullError` string (already in all 43 locales — no new key). This mattered most here: a service worker has no `window`, so utils.js's modal fallback never fired and these failures were completely silent.

What the audit understates: the **sync** error path was already correct and plumbed through ~9 popup callers via `storageFullError`. The gaps were precisely local, import, and background.

## Testing

Five new tests, each **verified to fail without its fix**:

- remove happens after set, not before (asserted on call order);
- nothing is deleted at all when the set fails — the case that used to empty every folder;
- a local write failure is reported rather than called back empty;
- the local prompts backup survives a failed sync (it is the only remaining copy);
- an import that cannot be saved rejects instead of announcing success.

`npx jest` — 607 passing. `python build.py --yes` — clean; both built background scripts re-checked with `node --check`.

## Manual verification owed

Fill sync storage near the quota, force a failure, and confirm the folders are **still there** after reopening the popup — that is the whole point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)