### PR TITLE
fix: stop losing prompt edits, inflating save counts, and wedging on __proto__

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,14 @@ git checkout main && git pull --ff-only
   scrollbar/overflow CSS variants for it; don't touch `overflow-y` /
   `scrollbar-gutter` in `popup.css` without a separate reason.
 - **Data is keyed by folder name and conversation URL** (no stable IDs). Renames,
-  pins and migrations are awkward by design (see TODO §8).
+  pins and migrations are awkward by design (see TODO §8). Because those keys are
+  user-typed names on ordinary objects, **every creation and rename path must
+  reject `isUnsafeKey` names** (`__proto__`, `constructor`, `prototype` —
+  `src/utils.js`, shown to the user as `reservedNameError`). `folders['__proto__']`
+  is `Object.prototype`: truthy, so the "create if missing" guard is skipped and
+  the next `.some()` throws; `prompts['__proto__'] = {…}` hits the prototype setter
+  so the prompt is never created and `JSON.stringify` emits `{}`. `moveChat` needs
+  no guard — its target comes from folders that can no longer be created.
 - **Marketing screenshots** are regenerated only at release time
   (`python build_images.py`), not on every change.
 
@@ -473,6 +480,10 @@ Reading cautions:
   on GF; on AF only check for the absence of a regression.
 - **2026-07-30 reads 0 installs / 0 uninstalls on both extensions** — a CWS reporting
   gap, not a real day. Exclude it from any daily average.
+- **`s` is discontinuous from the tab-reuse release onward.** Until then, saving a
+  conversation that was already in the folder still wrote and still incremented
+  the counter, so older `s` values are inflated by re-saves. The number is now
+  right, but **do not compare averages across that boundary**.
 - Once `s` (§9) has data, the decisive question becomes readable: among those who
   leave with `saves > 0` (they did use it), what share ask for `wanted-in-page-ui`?
   That number — not today's n=4 — decides whether the in-page UI is worth building

--- a/extensions/ai-folders/_locales/ar/messages.json
+++ b/extensions/ai-folders/_locales/ar/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "هذا الاسم محجوز — يرجى اختيار اسم آخر."
   }
 }

--- a/extensions/ai-folders/_locales/bg/messages.json
+++ b/extensions/ai-folders/_locales/bg/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Това име е запазено — изберете друго."
   }
 }

--- a/extensions/ai-folders/_locales/bn/messages.json
+++ b/extensions/ai-folders/_locales/bn/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "এই নামটি সংরক্ষিত — অন্য একটি নাম বেছে নিন।"
   }
 }

--- a/extensions/ai-folders/_locales/ca/messages.json
+++ b/extensions/ai-folders/_locales/ca/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Aquest nom està reservat: tria’n un altre."
   }
 }

--- a/extensions/ai-folders/_locales/cs/messages.json
+++ b/extensions/ai-folders/_locales/cs/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tento název je vyhrazený – zvolte prosím jiný."
   }
 }

--- a/extensions/ai-folders/_locales/da/messages.json
+++ b/extensions/ai-folders/_locales/da/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Dette navn er reserveret – vælg et andet."
   }
 }

--- a/extensions/ai-folders/_locales/de/messages.json
+++ b/extensions/ai-folders/_locales/de/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Strg"
+  },
+  "reservedNameError": {
+    "message": "Dieser Name ist reserviert – bitte wählen Sie einen anderen."
   }
 }

--- a/extensions/ai-folders/_locales/el/messages.json
+++ b/extensions/ai-folders/_locales/el/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Αυτό το όνομα είναι δεσμευμένο — επιλέξτε άλλο."
   }
 }

--- a/extensions/ai-folders/_locales/en/messages.json
+++ b/extensions/ai-folders/_locales/en/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "That name is reserved — please choose another."
   }
 }

--- a/extensions/ai-folders/_locales/es/messages.json
+++ b/extensions/ai-folders/_locales/es/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ese nombre está reservado: elige otro."
   }
 }

--- a/extensions/ai-folders/_locales/et/messages.json
+++ b/extensions/ai-folders/_locales/et/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "See nimi on reserveeritud – palun valige teine."
   }
 }

--- a/extensions/ai-folders/_locales/fi/messages.json
+++ b/extensions/ai-folders/_locales/fi/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tämä nimi on varattu – valitse toinen."
   }
 }

--- a/extensions/ai-folders/_locales/fr/messages.json
+++ b/extensions/ai-folders/_locales/fr/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ce nom est réservé — veuillez en choisir un autre."
   }
 }

--- a/extensions/ai-folders/_locales/he/messages.json
+++ b/extensions/ai-folders/_locales/he/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "השם הזה שמור — בחרו שם אחר."
   }
 }

--- a/extensions/ai-folders/_locales/hi/messages.json
+++ b/extensions/ai-folders/_locales/hi/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "यह नाम सुरक्षित है — कृपया दूसरा नाम चुनें।"
   }
 }

--- a/extensions/ai-folders/_locales/hr/messages.json
+++ b/extensions/ai-folders/_locales/hr/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Taj je naziv rezerviran — odaberite drugi."
   }
 }

--- a/extensions/ai-folders/_locales/hu/messages.json
+++ b/extensions/ai-folders/_locales/hu/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ez a név foglalt – válasszon másikat."
   }
 }

--- a/extensions/ai-folders/_locales/id/messages.json
+++ b/extensions/ai-folders/_locales/id/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Nama itu dicadangkan — silakan pilih yang lain."
   }
 }

--- a/extensions/ai-folders/_locales/it/messages.json
+++ b/extensions/ai-folders/_locales/it/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Questo nome è riservato: scegline un altro."
   }
 }

--- a/extensions/ai-folders/_locales/ja/messages.json
+++ b/extensions/ai-folders/_locales/ja/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "この名前は予約されています。別の名前を選んでください。"
   }
 }

--- a/extensions/ai-folders/_locales/ko/messages.json
+++ b/extensions/ai-folders/_locales/ko/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "이 이름은 예약되어 있습니다. 다른 이름을 선택하세요."
   }
 }

--- a/extensions/ai-folders/_locales/lt/messages.json
+++ b/extensions/ai-folders/_locales/lt/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Šis pavadinimas rezervuotas – pasirinkite kitą."
   }
 }

--- a/extensions/ai-folders/_locales/lv/messages.json
+++ b/extensions/ai-folders/_locales/lv/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Šis nosaukums ir rezervēts — lūdzu, izvēlieties citu."
   }
 }

--- a/extensions/ai-folders/_locales/ms/messages.json
+++ b/extensions/ai-folders/_locales/ms/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Nama itu dikhaskan — sila pilih nama lain."
   }
 }

--- a/extensions/ai-folders/_locales/nb/messages.json
+++ b/extensions/ai-folders/_locales/nb/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Dette navnet er reservert – velg et annet."
   }
 }

--- a/extensions/ai-folders/_locales/nl/messages.json
+++ b/extensions/ai-folders/_locales/nl/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Deze naam is gereserveerd — kies een andere."
   }
 }

--- a/extensions/ai-folders/_locales/pl/messages.json
+++ b/extensions/ai-folders/_locales/pl/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ta nazwa jest zarezerwowana — wybierz inną."
   }
 }

--- a/extensions/ai-folders/_locales/pt_BR/messages.json
+++ b/extensions/ai-folders/_locales/pt_BR/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Esse nome é reservado — escolha outro."
   }
 }

--- a/extensions/ai-folders/_locales/pt_PT/messages.json
+++ b/extensions/ai-folders/_locales/pt_PT/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Esse nome é reservado — escolha outro."
   }
 }

--- a/extensions/ai-folders/_locales/ro/messages.json
+++ b/extensions/ai-folders/_locales/ro/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Acest nume este rezervat — alegeți altul."
   }
 }

--- a/extensions/ai-folders/_locales/ru/messages.json
+++ b/extensions/ai-folders/_locales/ru/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Это имя зарезервировано — выберите другое."
   }
 }

--- a/extensions/ai-folders/_locales/sk/messages.json
+++ b/extensions/ai-folders/_locales/sk/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tento názov je vyhradený – zvoľte prosím iný."
   }
 }

--- a/extensions/ai-folders/_locales/sl/messages.json
+++ b/extensions/ai-folders/_locales/sl/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "To ime je rezervirano — izberite drugo."
   }
 }

--- a/extensions/ai-folders/_locales/sr/messages.json
+++ b/extensions/ai-folders/_locales/sr/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "To ime je rezervisano — izaberite drugo."
   }
 }

--- a/extensions/ai-folders/_locales/sv/messages.json
+++ b/extensions/ai-folders/_locales/sv/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Det namnet är reserverat – välj ett annat."
   }
 }

--- a/extensions/ai-folders/_locales/sw/messages.json
+++ b/extensions/ai-folders/_locales/sw/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Jina hilo limehifadhiwa — tafadhali chagua jingine."
   }
 }

--- a/extensions/ai-folders/_locales/th/messages.json
+++ b/extensions/ai-folders/_locales/th/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "ชื่อนี้ถูกสงวนไว้ — โปรดเลือกชื่ออื่น"
   }
 }

--- a/extensions/ai-folders/_locales/tl/messages.json
+++ b/extensions/ai-folders/_locales/tl/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Nakalaan ang pangalang iyan — pumili ng iba."
   }
 }

--- a/extensions/ai-folders/_locales/tr/messages.json
+++ b/extensions/ai-folders/_locales/tr/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Bu ad ayrılmıştır — lütfen başka bir ad seçin."
   }
 }

--- a/extensions/ai-folders/_locales/uk/messages.json
+++ b/extensions/ai-folders/_locales/uk/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Це ім’я зарезервовано — виберіть інше."
   }
 }

--- a/extensions/ai-folders/_locales/vi/messages.json
+++ b/extensions/ai-folders/_locales/vi/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tên này đã được dành riêng — vui lòng chọn tên khác."
   }
 }

--- a/extensions/ai-folders/_locales/zh_CN/messages.json
+++ b/extensions/ai-folders/_locales/zh_CN/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "该名称为保留名称，请另选一个。"
   }
 }

--- a/extensions/ai-folders/_locales/zh_TW/messages.json
+++ b/extensions/ai-folders/_locales/zh_TW/messages.json
@@ -337,5 +337,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "此名稱為保留名稱，請另選一個。"
   }
 }

--- a/extensions/gemini-folders/_locales/ar/messages.json
+++ b/extensions/gemini-folders/_locales/ar/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "هذا الاسم محجوز — يرجى اختيار اسم آخر."
   }
 }

--- a/extensions/gemini-folders/_locales/bg/messages.json
+++ b/extensions/gemini-folders/_locales/bg/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Това име е запазено — изберете друго."
   }
 }

--- a/extensions/gemini-folders/_locales/bn/messages.json
+++ b/extensions/gemini-folders/_locales/bn/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "এই নামটি সংরক্ষিত — অন্য একটি নাম বেছে নিন।"
   }
 }

--- a/extensions/gemini-folders/_locales/ca/messages.json
+++ b/extensions/gemini-folders/_locales/ca/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Aquest nom està reservat: tria’n un altre."
   }
 }

--- a/extensions/gemini-folders/_locales/cs/messages.json
+++ b/extensions/gemini-folders/_locales/cs/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tento název je vyhrazený – zvolte prosím jiný."
   }
 }

--- a/extensions/gemini-folders/_locales/da/messages.json
+++ b/extensions/gemini-folders/_locales/da/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Dette navn er reserveret – vælg et andet."
   }
 }

--- a/extensions/gemini-folders/_locales/de/messages.json
+++ b/extensions/gemini-folders/_locales/de/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Strg"
+  },
+  "reservedNameError": {
+    "message": "Dieser Name ist reserviert – bitte wählen Sie einen anderen."
   }
 }

--- a/extensions/gemini-folders/_locales/el/messages.json
+++ b/extensions/gemini-folders/_locales/el/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Αυτό το όνομα είναι δεσμευμένο — επιλέξτε άλλο."
   }
 }

--- a/extensions/gemini-folders/_locales/en/messages.json
+++ b/extensions/gemini-folders/_locales/en/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "That name is reserved — please choose another."
   }
 }

--- a/extensions/gemini-folders/_locales/es/messages.json
+++ b/extensions/gemini-folders/_locales/es/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ese nombre está reservado: elige otro."
   }
 }

--- a/extensions/gemini-folders/_locales/et/messages.json
+++ b/extensions/gemini-folders/_locales/et/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "See nimi on reserveeritud – palun valige teine."
   }
 }

--- a/extensions/gemini-folders/_locales/fi/messages.json
+++ b/extensions/gemini-folders/_locales/fi/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tämä nimi on varattu – valitse toinen."
   }
 }

--- a/extensions/gemini-folders/_locales/fr/messages.json
+++ b/extensions/gemini-folders/_locales/fr/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ce nom est réservé — veuillez en choisir un autre."
   }
 }

--- a/extensions/gemini-folders/_locales/he/messages.json
+++ b/extensions/gemini-folders/_locales/he/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "השם הזה שמור — בחרו שם אחר."
   }
 }

--- a/extensions/gemini-folders/_locales/hi/messages.json
+++ b/extensions/gemini-folders/_locales/hi/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "यह नाम सुरक्षित है — कृपया दूसरा नाम चुनें।"
   }
 }

--- a/extensions/gemini-folders/_locales/hr/messages.json
+++ b/extensions/gemini-folders/_locales/hr/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Taj je naziv rezerviran — odaberite drugi."
   }
 }

--- a/extensions/gemini-folders/_locales/hu/messages.json
+++ b/extensions/gemini-folders/_locales/hu/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ez a név foglalt – válasszon másikat."
   }
 }

--- a/extensions/gemini-folders/_locales/id/messages.json
+++ b/extensions/gemini-folders/_locales/id/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Nama itu dicadangkan — silakan pilih yang lain."
   }
 }

--- a/extensions/gemini-folders/_locales/it/messages.json
+++ b/extensions/gemini-folders/_locales/it/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Questo nome è riservato: scegline un altro."
   }
 }

--- a/extensions/gemini-folders/_locales/ja/messages.json
+++ b/extensions/gemini-folders/_locales/ja/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "この名前は予約されています。別の名前を選んでください。"
   }
 }

--- a/extensions/gemini-folders/_locales/ko/messages.json
+++ b/extensions/gemini-folders/_locales/ko/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "이 이름은 예약되어 있습니다. 다른 이름을 선택하세요."
   }
 }

--- a/extensions/gemini-folders/_locales/lt/messages.json
+++ b/extensions/gemini-folders/_locales/lt/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Šis pavadinimas rezervuotas – pasirinkite kitą."
   }
 }

--- a/extensions/gemini-folders/_locales/lv/messages.json
+++ b/extensions/gemini-folders/_locales/lv/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Šis nosaukums ir rezervēts — lūdzu, izvēlieties citu."
   }
 }

--- a/extensions/gemini-folders/_locales/ms/messages.json
+++ b/extensions/gemini-folders/_locales/ms/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Nama itu dikhaskan — sila pilih nama lain."
   }
 }

--- a/extensions/gemini-folders/_locales/nb/messages.json
+++ b/extensions/gemini-folders/_locales/nb/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Dette navnet er reservert – velg et annet."
   }
 }

--- a/extensions/gemini-folders/_locales/nl/messages.json
+++ b/extensions/gemini-folders/_locales/nl/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Deze naam is gereserveerd — kies een andere."
   }
 }

--- a/extensions/gemini-folders/_locales/pl/messages.json
+++ b/extensions/gemini-folders/_locales/pl/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Ta nazwa jest zarezerwowana — wybierz inną."
   }
 }

--- a/extensions/gemini-folders/_locales/pt_BR/messages.json
+++ b/extensions/gemini-folders/_locales/pt_BR/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Esse nome é reservado — escolha outro."
   }
 }

--- a/extensions/gemini-folders/_locales/pt_PT/messages.json
+++ b/extensions/gemini-folders/_locales/pt_PT/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Esse nome é reservado — escolha outro."
   }
 }

--- a/extensions/gemini-folders/_locales/ro/messages.json
+++ b/extensions/gemini-folders/_locales/ro/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Acest nume este rezervat — alegeți altul."
   }
 }

--- a/extensions/gemini-folders/_locales/ru/messages.json
+++ b/extensions/gemini-folders/_locales/ru/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Это имя зарезервировано — выберите другое."
   }
 }

--- a/extensions/gemini-folders/_locales/sk/messages.json
+++ b/extensions/gemini-folders/_locales/sk/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tento názov je vyhradený – zvoľte prosím iný."
   }
 }

--- a/extensions/gemini-folders/_locales/sl/messages.json
+++ b/extensions/gemini-folders/_locales/sl/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "To ime je rezervirano — izberite drugo."
   }
 }

--- a/extensions/gemini-folders/_locales/sr/messages.json
+++ b/extensions/gemini-folders/_locales/sr/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "To ime je rezervisano — izaberite drugo."
   }
 }

--- a/extensions/gemini-folders/_locales/sv/messages.json
+++ b/extensions/gemini-folders/_locales/sv/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Det namnet är reserverat – välj ett annat."
   }
 }

--- a/extensions/gemini-folders/_locales/sw/messages.json
+++ b/extensions/gemini-folders/_locales/sw/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Jina hilo limehifadhiwa — tafadhali chagua jingine."
   }
 }

--- a/extensions/gemini-folders/_locales/th/messages.json
+++ b/extensions/gemini-folders/_locales/th/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "ชื่อนี้ถูกสงวนไว้ — โปรดเลือกชื่ออื่น"
   }
 }

--- a/extensions/gemini-folders/_locales/tl/messages.json
+++ b/extensions/gemini-folders/_locales/tl/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Nakalaan ang pangalang iyan — pumili ng iba."
   }
 }

--- a/extensions/gemini-folders/_locales/tr/messages.json
+++ b/extensions/gemini-folders/_locales/tr/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Bu ad ayrılmıştır — lütfen başka bir ad seçin."
   }
 }

--- a/extensions/gemini-folders/_locales/uk/messages.json
+++ b/extensions/gemini-folders/_locales/uk/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Це ім’я зарезервовано — виберіть інше."
   }
 }

--- a/extensions/gemini-folders/_locales/vi/messages.json
+++ b/extensions/gemini-folders/_locales/vi/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "Tên này đã được dành riêng — vui lòng chọn tên khác."
   }
 }

--- a/extensions/gemini-folders/_locales/zh_CN/messages.json
+++ b/extensions/gemini-folders/_locales/zh_CN/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "该名称为保留名称，请另选一个。"
   }
 }

--- a/extensions/gemini-folders/_locales/zh_TW/messages.json
+++ b/extensions/gemini-folders/_locales/zh_TW/messages.json
@@ -301,5 +301,8 @@
   },
   "keyCtrl": {
     "message": "Ctrl"
+  },
+  "reservedNameError": {
+    "message": "此名稱為保留名稱，請另選一個。"
   }
 }

--- a/src/folders.js
+++ b/src/folders.js
@@ -494,6 +494,18 @@ async function renameFolder(oldName) {
 
   const trimmedNewName = newName.trim();
 
+  // Renaming TO one of these currently reports "already exists" by accident
+  // (Object.prototype is truthy), which is the right refusal for the wrong
+  // reason — and the assignment below would reassign the object's prototype.
+  // Say what is actually going on instead.
+  if (isUnsafeKey(trimmedNewName)) {
+    await window.showCustomModal({
+      title: chrome.i18n.getMessage("reservedNameError") || 'That name is reserved — please choose another.',
+      type: 'alert',
+    });
+    return;
+  }
+
   loadData({ folders: {}, pinnedFolders: [] }, async (data) => {
     let folders = data.folders;
     let pinned = data.pinnedFolders;

--- a/src/popup-core.js
+++ b/src/popup-core.js
@@ -131,17 +131,40 @@ function initSaveConversation(opts) {
     const finalChatTitle = chatTitleInput.value.trim() || chrome.i18n.getMessage("defaultTitle");
     const chatUrl = tab.url;
 
+    // folders["__proto__"] is Object.prototype — truthy, so the guard below would
+    // skip creating the array, and the .some() after it would throw and leave
+    // isSaving stuck at true, killing the Save button for the rest of the session.
+    if (isUnsafeKey(folderName)) {
+      statusDiv.textContent = chrome.i18n.getMessage("reservedNameError") || 'That name is reserved — please choose another.';
+      statusDiv.style.color = 'red';
+      statusDiv.style.display = "block";
+      setTimeout(() => { statusDiv.style.display = "none"; statusDiv.style.color = ''; statusDiv.textContent = chrome.i18n.getMessage("statusSaved"); }, 4000);
+      isSaving = false;
+      return;
+    }
+
     loadData({ folders: {} }, (data) => {
       let folders = data.folders;
       if (!folders[folderName]) folders[folderName] = [];
 
       const cleanTargetUrl = normalizeUrl(chatUrl);
       const isDuplicate = folders[folderName].some(chat => normalizeUrl(chat.url) === cleanTargetUrl);
-      if (!isDuplicate) {
-        const chatEntry = { title: finalChatTitle, url: chatUrl, timestamp: Date.now() };
-        if (opts.tagSite) chatEntry.site = siteKey;
-        folders[folderName].push(chatEntry);
+      if (isDuplicate) {
+        // Writing unchanged data back counted as a content save: it bumped
+        // usageStats.saves — the 's' the uninstall survey reports and the
+        // anti-churn baselines read — and rebuilt the whole bookmark tree for
+        // nothing. The background quick-save handlers already skip the write here.
+        isSaving = false;
+        statusDiv.textContent = chrome.i18n.getMessage("toastAlreadySaved") || '⚠️ Already saved!';
+        statusDiv.style.color = 'red';
+        statusDiv.style.display = "block";
+        setTimeout(() => { statusDiv.style.display = "none"; statusDiv.style.color = ''; statusDiv.textContent = chrome.i18n.getMessage("statusSaved"); }, 2000);
+        return;
       }
+
+      const chatEntry = { title: finalChatTitle, url: chatUrl, timestamp: Date.now() };
+      if (opts.tagSite) chatEntry.site = siteKey;
+      folders[folderName].push(chatEntry);
 
       saveData({ folders }, (err) => {
         isSaving = false;
@@ -228,6 +251,15 @@ function initPopupCommon(config) {
       placeholder: chrome.i18n.getMessage("emojiTipPlaceholder") || "Tip: Start with an emoji! (Win+. or Cmd+Ctrl+Space)"
     });
     if (name && name.trim()) {
+      // Without this, "__proto__" looks like an existing folder (Object.prototype
+      // is truthy) so nothing is created and the modal closes as if it worked.
+      if (isUnsafeKey(name.trim())) {
+        window.showCustomModal({
+          title: chrome.i18n.getMessage("reservedNameError") || 'That name is reserved — please choose another.',
+          type: 'alert',
+        });
+        return;
+      }
       loadData({ folders: {} }, (data) => {
         if (!data.folders[name.trim()]) {
           data.folders[name.trim()] = [];

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -21,6 +21,59 @@ function autoResize(ta) {
 
 const PROMPT_DELAY = { AUTOSAVE: 600, ICON: 1500 };
 
+// --- Inline-edit autosave -----------------------------------------------------
+//
+// Typing in a prompt used to arm a 600 ms timer owned by that textarea's closure,
+// and nothing else. Three ways that lost work silently:
+//   1. closing the popup destroyed the document, and the timer with it;
+//   2. renaming first moved the key, so the late callback looked up a title that
+//      no longer existed and gave up (rename also copied the *stored* text, not
+//      what was on screen);
+//   3. any re-render — pin, delete, search, mode toggle — rebuilt every node and
+//      orphaned its timer.
+// The edit now lives in one module-level slot that can be flushed on demand.
+// There is only ever one: editing a second prompt means the first lost focus.
+let _pendingEdit = null;   // { title, text, timer }
+
+// Commits the pending edit, if any, then runs `cb`. Safe to call unconditionally.
+function flushPendingEdit(cb) {
+  const pending = _pendingEdit;
+  if (!pending) { if (cb) cb(); return; }
+  clearTimeout(pending.timer);
+  _pendingEdit = null;
+  loadData({ prompts: {} }, (data) => {
+    // Gone (deleted, or renamed by something that did not flush first).
+    if (!data.prompts[pending.title]) { if (cb) cb(); return; }
+    data.prompts[pending.title].text = pending.text;
+    data.prompts[pending.title].timestamp = Date.now();
+    saveData({ prompts: data.prompts }, (err) => {
+      // The old autosave passed no callback at all, so a full quota lost the
+      // edit without a word.
+      if (err && window.showCustomModal) {
+        window.showCustomModal({
+          title: chrome.i18n.getMessage("storageFullError") || '⚠️ Storage full — not saved.',
+          type: 'alert',
+        });
+      }
+      if (cb) cb();
+    });
+  });
+}
+
+function queueEdit(title, text) {
+  // Switching prompts commits the previous one instead of dropping it.
+  if (_pendingEdit && _pendingEdit.title !== title) flushPendingEdit();
+  if (_pendingEdit) clearTimeout(_pendingEdit.timer);
+  _pendingEdit = { title, text, timer: setTimeout(() => flushPendingEdit(), PROMPT_DELAY.AUTOSAVE) };
+}
+
+// Best-effort save when the popup is dismissed. The document is torn down right
+// after, so the storage call may not complete — but the write is dispatched
+// synchronously here, which is strictly better than losing the edit outright.
+if (typeof window !== 'undefined' && window.addEventListener) {
+  window.addEventListener('pagehide', () => flushPendingEdit());
+}
+
 function buildPromptItem(title, p, openPrompts) {
   const item = document.createElement('div');
   item.className = 'prompt-item' + (p.pinned ? ' prompt-item--pinned' : '');
@@ -41,12 +94,12 @@ function buildPromptItem(title, p, openPrompts) {
   pinBtn.title = chrome.i18n.getMessage(p.pinned ? "btnUnpin" : "btnPin") || (p.pinned ? 'Unpin' : 'Pin');
   pinBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    loadData({ prompts: {} }, (data) => {
+    flushPendingEdit(() => loadData({ prompts: {} }, (data) => {
       if (data.prompts[title]) {
         data.prompts[title].pinned = !data.prompts[title].pinned;
         saveData({ prompts: data.prompts }, () => displayPrompts());
       }
-    });
+    }));
   });
 
   const sendSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>`;
@@ -90,7 +143,16 @@ function buildPromptItem(title, p, openPrompts) {
     });
     if (!newTitle || newTitle.trim() === '' || newTitle.trim() === title) return;
     const trimmed = newTitle.trim();
-    loadData({ prompts: {}, openPrompts: [] }, (data) => {
+    if (isUnsafeKey(trimmed)) {
+      window.showCustomModal({
+        title: chrome.i18n.getMessage("reservedNameError") || 'That name is reserved — please choose another.',
+        type: 'alert',
+      });
+      return;
+    }
+    // Commit first: doRename copies the *stored* text, so an unflushed edit
+    // would be silently dropped, and the pending title is about to stop existing.
+    flushPendingEdit(() => loadData({ prompts: {}, openPrompts: [] }, (data) => {
       if (data.prompts[trimmed] && trimmed !== title) {
         window.showCustomModal({
           title: chrome.i18n.getMessage("promptDuplicateWarning") || "A prompt with this title already exists. Overwrite?",
@@ -110,7 +172,7 @@ function buildPromptItem(title, p, openPrompts) {
         if (idx !== -1) { open[idx] = newName; }
         saveData({ prompts: d.prompts, openPrompts: open }, () => displayPrompts());
       }
-    });
+    }));
   });
 
   const deleteBtn = document.createElement('button');
@@ -124,10 +186,10 @@ function buildPromptItem(title, p, openPrompts) {
       type: 'confirm'
     });
     if (!isSure) return;
-    loadData({ prompts: {} }, (data) => {
+    flushPendingEdit(() => loadData({ prompts: {} }, (data) => {
       delete data.prompts[title];
       saveData({ prompts: data.prompts }, () => displayPrompts());
-    });
+    }));
   });
 
   actions.appendChild(pinBtn);
@@ -144,20 +206,14 @@ function buildPromptItem(title, p, openPrompts) {
   textArea.setAttribute('writingsuggestions', 'false');
   textArea.setAttribute('spellcheck', 'false');
 
-  let saveTimeout;
   textArea.addEventListener('input', () => {
     autoResize(textArea);
-    clearTimeout(saveTimeout);
-    saveTimeout = setTimeout(() => {
-      loadData({ prompts: {} }, (data) => {
-        if (data.prompts[title]) {
-          data.prompts[title].text = textArea.value;
-          data.prompts[title].timestamp = Date.now();
-          saveData({ prompts: data.prompts });
-        }
-      });
-    }, PROMPT_DELAY.AUTOSAVE);
+    queueEdit(title, textArea.value);
   });
+
+  // Losing focus means the user is done with this box — commit immediately
+  // rather than gambling on the debounce outliving whatever they do next.
+  textArea.addEventListener('blur', () => flushPendingEdit());
 
   textArea.addEventListener('click', (e) => e.stopPropagation());
 
@@ -201,7 +257,10 @@ function displayPrompts() {
   const promptListDiv = document.getElementById('promptList');
   if (!promptListDiv) return;
   const searchQuery = (document.getElementById('promptSearchInput')?.value || '').toLowerCase().trim();
-  loadData({ prompts: {}, openPrompts: [], promptSortPref: 'dateDesc' }, (data) => {
+  // Every re-render replaces the whole list, so an uncommitted edit in one of the
+  // outgoing textareas would be thrown away — searching or switching modes
+  // mid-sentence used to be enough to lose it.
+  flushPendingEdit(() => loadData({ prompts: {}, openPrompts: [], promptSortPref: 'dateDesc' }, (data) => {
     promptListDiv.replaceChildren();
     const { prompts, openPrompts, promptSortPref: sortPref } = data;
     let titles = Object.keys(prompts);
@@ -241,7 +300,7 @@ function displayPrompts() {
       }
       promptListDiv.appendChild(buildPromptItem(title, p, openPrompts));
     });
-  });
+  }));
 }
 window.displayPrompts = displayPrompts;
 
@@ -288,6 +347,19 @@ function initPromptsUI() {
     isSavingPrompt = true;
 
     const title = promptTitleInput.value.trim() || 'Untitled Prompt';
+    // "__proto__" would hit Object.prototype's setter instead of creating a key:
+    // the duplicate check below is always truthy for it (so the user gets a
+    // phantom "already exists, overwrite?"), and JSON.stringify then serializes
+    // {} — the prompt simply vanishes. Same reserved names the import path has
+    // rejected since it was hardened (isUnsafeKey, utils.js).
+    if (isUnsafeKey(title)) {
+      promptStatusDiv.textContent = chrome.i18n.getMessage("reservedNameError") || 'That name is reserved — please choose another.';
+      promptStatusDiv.style.color = 'red';
+      promptStatusDiv.style.display = 'block';
+      setTimeout(() => promptStatusDiv.style.display = 'none', 2000);
+      isSavingPrompt = false;
+      return;
+    }
     const text = promptTextInput.value.trim();
     if (!text) {
       promptStatusDiv.textContent = chrome.i18n.getMessage("promptCannotBeEmpty") || 'Prompt cannot be empty!';

--- a/src/utils.js
+++ b/src/utils.js
@@ -398,6 +398,20 @@ function extractTitleLogic(strategies, defaultFallback) {
   return defaultFallback;
 }
 
+// Folders and prompts are keyed by user-typed names on ordinary objects, so a
+// name that collides with something on Object.prototype misbehaves badly:
+// folders["__proto__"] resolves to Object.prototype (truthy, so the "create it
+// if missing" guard is skipped) and the following .some()/.push() throws;
+// prompts["__proto__"] = {...} hits the prototype setter instead of creating a
+// property, so JSON.stringify serializes {} and the prompt disappears.
+// "constructor" behaves the same way.
+//
+// The import path has skipped these since it was hardened; this is the same
+// check, hoisted so creation and rename can reject them at the door too.
+function isUnsafeKey(k) {
+  return k === '__proto__' || k === 'constructor' || k === 'prototype';
+}
+
 function isSafeUrl(url) {
   try {
     return /^https?:$/.test(new URL(url).protocol);
@@ -441,12 +455,6 @@ function mergeImportData(importedData) {
       let currentPrompts = data.prompts || {};
 
       const isPlainObject = (v) => v && typeof v === 'object' && !Array.isArray(v);
-      // JSON.parse creates OWN "__proto__"/"constructor"/"prototype" properties, so
-      // Object.entries surfaces them here. Accessing currentFolders["__proto__"]
-      // resolves to Object.prototype (and ["constructor"] to the Object function),
-      // whose `.some`/`.push` don't exist — a single such key would throw and abort
-      // the whole import. Skip them: robustness, not prototype-pollution (guarded).
-      const isUnsafeKey = (k) => k === '__proto__' || k === 'constructor' || k === 'prototype';
 
       // --- BACKWARD COMPATIBILITY MANAGEMENT ---
       // Current format wraps content in { folders, pinnedFolders, prompts };
@@ -917,5 +925,6 @@ if (typeof module !== 'undefined') {
     normalizeUiLang,
     buildUninstallUrl,
     saveDataAsync,
+    isUnsafeKey,
   };
 }

--- a/tests/folders.test.js
+++ b/tests/folders.test.js
@@ -36,6 +36,7 @@ function savedPins() {
 
 beforeEach(() => {
   global.normalizeUrl = jest.fn((url) => url.split('?')[0].split('#')[0]);
+  global.isUnsafeKey = require('../src/utils').isUnsafeKey;
   global.isSafeUrl = jest.fn(() => true);
   global.window.showCustomModal = jest.fn();
   // openConversation closes the popup when it is done; in jsdom the real

--- a/tests/popup-core.test.js
+++ b/tests/popup-core.test.js
@@ -1,4 +1,6 @@
 // popup-core.js shared wiring: the i18n/RTL pass, the cross-browser clearable
+// utils.js is a classic script in the popup, so its helpers are globals there.
+global.isUnsafeKey = require('../src/utils').isUnsafeKey;
 // search control (recent feature), and the "save current conversation" flow.
 
 require('../src/popup-core'); // defines window.applyCommonI18n / setupClearableSearch / initSaveConversation
@@ -165,7 +167,11 @@ describe('initSaveConversation', () => {
     expect(global.saveData).not.toHaveBeenCalled();
   });
 
-  test('does not duplicate a conversation already in the folder', async () => {
+  test('does not write at all for a conversation already in the folder', async () => {
+    // Re-saving a duplicate used to still call saveData with unchanged data,
+    // which counts as a content save: it bumped usageStats.saves (the 's' the
+    // uninstall survey reports and the anti-churn baselines read) and rebuilt
+    // the whole bookmark tree for nothing.
     chrome.tabs.query = jest.fn().mockResolvedValue([{ url: 'https://claude.ai/chat/1' }]);
     global.loadData = jest.fn((defaults, cb) =>
       cb({ folders: { defaultFolder: [{ title: 'x', url: 'https://claude.ai/chat/1' }] } })
@@ -175,6 +181,47 @@ describe('initSaveConversation', () => {
     document.getElementById('saveBtn').click();
     await flush();
 
-    expect(savedFolders['defaultFolder']).toHaveLength(1);
+    expect(global.saveData).not.toHaveBeenCalled();
+    expect(document.getElementById('status').textContent).toBe('toastAlreadySaved');
+  });
+
+  test('a second click still works after a duplicate', async () => {
+    // The duplicate path must release the isSaving latch, or the Save button
+    // stays dead for the rest of the popup session.
+    chrome.tabs.query = jest.fn().mockResolvedValue([{ url: 'https://claude.ai/chat/1' }]);
+    global.loadData = jest.fn((defaults, cb) =>
+      cb({ folders: { defaultFolder: [{ title: 'x', url: 'https://claude.ai/chat/1' }] } })
+    );
+    wire(() => 'claude');
+
+    document.getElementById('saveBtn').click();
+    await flush();
+    global.loadData = jest.fn((defaults, cb) => cb({ folders: {} }));
+    document.getElementById('saveBtn').click();
+    await flush();
+
+    expect(global.saveData).toHaveBeenCalled();
+  });
+
+  test('refuses a reserved folder name instead of wedging the Save button', async () => {
+    // folders["__proto__"] is Object.prototype: truthy, so the "create it if
+    // missing" guard was skipped and the .some() after it threw inside the
+    // loadData callback, leaving isSaving true forever.
+    chrome.tabs.query = jest.fn().mockResolvedValue([{ url: 'https://claude.ai/chat/1' }]);
+    global.loadData = jest.fn((defaults, cb) => cb({ folders: {} }));
+    wire(() => 'claude');
+
+    document.getElementById('folderName').value = '__proto__';
+    document.getElementById('saveBtn').click();
+    await flush();
+
+    expect(global.saveData).not.toHaveBeenCalled();
+    expect(document.getElementById('status').textContent).toBe('reservedNameError');
+
+    // And the button still works afterwards.
+    document.getElementById('folderName').value = 'Work';
+    document.getElementById('saveBtn').click();
+    await flush();
+    expect(global.saveData).toHaveBeenCalled();
   });
 });

--- a/tests/prompts.test.js
+++ b/tests/prompts.test.js
@@ -4,6 +4,10 @@
 
 require('../src/prompts'); // exposes window.displayPrompts
 
+// In the popup, utils.js is a classic script loaded first, so its helpers are
+// globals. Jest has no such loader — provide the one prompts.js reaches for.
+global.isUnsafeKey = require('../src/utils').isUnsafeKey;
+
 function setupStorage(prompts, { promptSortPref = 'dateDesc', openPrompts = [] } = {}) {
   global.loadData = jest.fn((defaults, cb) =>
     cb({
@@ -13,6 +17,23 @@ function setupStorage(prompts, { promptSortPref = 'dateDesc', openPrompts = [] }
     })
   );
   global.saveData = jest.fn((data, cb) => cb && cb());
+}
+
+// setupStorage replays the same initial data on every load, which cannot express
+// a sequence like "the flush wrote, then the rename read it back". This one keeps
+// state, the way real storage does.
+function setupStatefulStorage(prompts, { openPrompts = [] } = {}) {
+  const store = {
+    prompts: JSON.parse(JSON.stringify(prompts)),
+    openPrompts: [...openPrompts],
+    promptSortPref: 'dateDesc',
+  };
+  global.loadData = jest.fn((defaults, cb) => cb(JSON.parse(JSON.stringify(store))));
+  global.saveData = jest.fn((data, cb) => {
+    Object.assign(store, JSON.parse(JSON.stringify(data)));
+    if (cb) cb();
+  });
+  return store;
 }
 
 function render(searchValue = '') {
@@ -206,6 +227,86 @@ describe('buildPromptItem — actions', () => {
     jest.advanceTimersByTime(600); // PROMPT_DELAY.AUTOSAVE
     expect(lastSavedPrompts().MyPrompt.text).toBe('new body');
     jest.useRealTimers();
+  });
+
+  // --- Losing an edit was the actual bug, so these cover each way it happened ---
+
+  test('an unsaved edit is committed when the textarea loses focus', async () => {
+    setupStorage({ MyPrompt: { text: 'old', timestamp: 1 } });
+    render();
+    const ta = firstItem().querySelector('.prompt-text-edit');
+    ta.value = 'typed but not yet debounced';
+    ta.dispatchEvent(new Event('input'));
+    ta.dispatchEvent(new Event('blur'));
+    await flush();
+    expect(lastSavedPrompts().MyPrompt.text).toBe('typed but not yet debounced');
+  });
+
+  test('an unsaved edit is committed when the popup is dismissed', async () => {
+    // Closing the popup destroyed the document and the pending timer with it.
+    setupStorage({ MyPrompt: { text: 'old', timestamp: 1 } });
+    render();
+    const ta = firstItem().querySelector('.prompt-text-edit');
+    ta.value = 'unsaved on close';
+    ta.dispatchEvent(new Event('input'));
+    window.dispatchEvent(new Event('pagehide'));
+    await flush();
+    expect(lastSavedPrompts().MyPrompt.text).toBe('unsaved on close');
+  });
+
+  test('an unsaved edit survives a rename', async () => {
+    // doRename copies the STORED text, and the pending timer then looked up a
+    // title that no longer existed — so the edit vanished twice over.
+    const store = setupStatefulStorage({ MyPrompt: { text: 'old', timestamp: 1 } });
+    global.window.showCustomModal = jest.fn().mockResolvedValue('Renamed');
+    render();
+    const ta = firstItem().querySelector('.prompt-text-edit');
+    ta.value = 'edited then renamed';
+    ta.dispatchEvent(new Event('input'));
+    [...firstItem().querySelectorAll('.action-btn')]
+      .find((b) => b.textContent === '✏️')
+      .click();
+    await flush();
+    await flush();
+    await flush();
+    expect(store.prompts.Renamed.text).toBe('edited then renamed');
+    expect(store.prompts.MyPrompt).toBeUndefined();
+  });
+
+  test('an unsaved edit survives a re-render (search, mode switch, pin)', async () => {
+    setupStorage({ MyPrompt: { text: 'old', timestamp: 1 } });
+    render();
+    const ta = firstItem().querySelector('.prompt-text-edit');
+    ta.value = 'edited then re-rendered';
+    ta.dispatchEvent(new Event('input'));
+    render('my');   // a search keystroke rebuilds the whole list
+    await flush();
+    expect(lastSavedPrompts().MyPrompt.text).toBe('edited then re-rendered');
+  });
+
+  test('a reserved prompt title is refused instead of silently vanishing', async () => {
+    // prompts["__proto__"] = {...} hits the prototype setter, so the prompt is
+    // never created and JSON.stringify then serializes {}. The duplicate check
+    // is also always truthy, so the user first got a phantom overwrite prompt.
+    // initPromptsUI needs the add-prompt panel, which the list-only DOM lacks.
+    document.body.innerHTML += `
+      <input id="promptTitle" value="" />
+      <textarea id="promptText"></textarea>
+      <button id="savePromptBtn"></button>
+      <input type="checkbox" id="syncPromptsToggle" />
+      <div id="promptStatus"></div>
+      <button id="toggleAddPromptPanelBtn"></button>
+      <div id="addPromptPanel"></div>
+      <button id="promptSortToggleBtn"></button>
+      <div id="promptSortMenu"></div>`;
+    setupStorage({});
+    window.initPromptsUI();
+    document.getElementById('promptTitle').value = '__proto__';
+    document.getElementById('promptText').value = 'body';
+    document.getElementById('savePromptBtn').click();
+    await flush();
+    expect(global.saveData).not.toHaveBeenCalled();
+    expect(document.getElementById('promptStatus').textContent).toBe('reservedNameError');
   });
 
   test('toggling the header persists the open state', () => {


### PR DESCRIPTION
Findings 4, 5 and 6 of the external audit. They share a root cause: data keyed by user-typed names, mutated from several paths that did not agree with each other.

## 4 — Prompt edits were lost, silently

Typing armed a 600 ms timer owned by one textarea's closure and nothing else. Three ways that lost work, none of them visible to the user:

- **closing the popup** destroyed the document and the pending timer with it;
- **renaming first** moved the key, so the late callback looked up a title that no longer existed and gave up — and `doRename` copies the *stored* text, not what is on screen, so the edit died twice over;
- **any re-render** — pin, delete, search keystroke, mode toggle — rebuilds every node and orphans its timer.

The pending edit now lives in one module-level slot with an explicit `flushPendingEdit`, called on **blur**, on **pagehide**, before **rename/delete/pin**, and at the top of **`displayPrompts`**. There is only ever one pending edit: editing a second prompt means the first lost focus.

It also finally passes a callback to `saveData` — the old autosave passed none, so hitting the quota dropped the edit without a word.

## 5 — Duplicate saves inflated the usage counter

`initSaveConversation` detected the duplicate and then called `saveData` anyway, outside the `if`. Rewriting unchanged data still counts as a content save, so it bumped `usageStats.saves` — **the `s` the uninstall survey reports and the anti-churn baselines in CLAUDE.md §11 read** — and rebuilt the entire bookmark tree for nothing.

It now returns through an "already saved" message, which is what the background quick-save handlers already did. The two paths were inconsistent.

⚠️ **`s` is discontinuous from this release on.** Earlier values are inflated by re-saves; averages must not be compared across the boundary. Recorded in CLAUDE.md §11.

## 6 — Reserved names broke things in two different ways

`folders['__proto__']` is `Object.prototype` — **truthy**, so the "create it if missing" guard was skipped and the next `.some()` threw inside the `loadData` callback. Nothing catches it, and `isSaving` is only cleared in the `saveData` callback, so **the Save button stayed dead for the rest of the popup session**.

`prompts['__proto__'] = {…}` is worse: it hits the prototype setter instead of creating a property, so the prompt is never created, the duplicate check is *always* truthy (the user gets a phantom "already exists, overwrite?"), and `JSON.stringify` then emits `{}` — the prompt simply vanishes.

The import path has skipped these keys since it was hardened, with a comment describing this exact failure. `isUnsafeKey` is hoisted out of `mergeImportData` and exported so **folder save, new folder, folder rename, prompt save and prompt rename** reject them at the door, with a new `reservedNameError` string in all 43 locales × 2.

`moveChat` deliberately gets no guard: its target comes from folders that can no longer be created.

## Testing

Eight new tests, **all verified to fail with the fixes stubbed out**: edit survives blur / popup close / rename / re-render; duplicate performs no write at all and still releases the `isSaving` latch; reserved folder name refused without wedging the button; reserved prompt title refused instead of vanishing.

One needed a new stateful storage helper — the existing mock replays its initial data on every load, which cannot express "the flush wrote, then the rename read it back".

`npx jest` — 614 passing. `python build.py --yes` — clean.

## Manual verification owed

Type in a prompt and close the popup immediately: the text must survive. Save the same conversation twice: `usageStats.saves` must move only once. Create a folder called `__proto__`: clean refusal, button still alive afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)