### PR TITLE
build: make the test gate fail-closed and package in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,41 @@ jobs:
 
       - name: Run test suite
         run: npm test
+
+  # CI used to stop at the tests, so a regression in build.py — a dropped file,
+  # a permission that drifted, an unresolved placeholder — could only be caught
+  # by hand at release time. This packages both extensions for both browsers and
+  # inspects the artifacts. build.py re-runs Jest itself and is now fail-closed,
+  # so this job also proves the test gate still blocks a red suite.
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all extensions
+        run: python build.py --yes
+
+      - name: Validate the built artifacts
+        run: python tools/validate_build.py
+
+      - name: Fail if the build left the tree dirty
+        run: |
+          # build.py stamps package.json/package-lock.json from the manifest. If
+          # that changes anything here, the committed versions were out of sync.
+          git diff --exit-code || {
+            echo "::error::build.py modified tracked files — commit the version sync"
+            exit 1
+          }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,15 +110,24 @@ build_images.py              Regenerates marketing screenshots (release-time onl
 npx jest                 # full suite
 ```
 
-**Build** (runs Jest first, then asks whether to continue if it fails):
+**Build** (runs Jest first and **aborts** if it fails):
 ```bash
-python build.py          # interactive — a failing suite prompts, so it stops unless you say yes
+python build.py          # interactive
 python build.py --yes    # non-interactive (also -y); use this in automation
+python build.py --force  # build anyway on a red suite — deliberate use only
 ```
-⚠️ **`--yes` answers that prompt for you**, so a failing suite does *not* abort the
-build (`run_tests` → `confirm`, build.py:180). A green `🎉 Build finished` is
-therefore **not** evidence that the tests passed — always run `npx jest`
-separately and read its summary.
+`--yes` only suppresses prompts; it does **not** wave through failing tests
+(it used to, which meant a green `🎉 Build finished` proved nothing). Overriding
+a red suite now takes the explicit `--force`.
+
+**Validate what was built:**
+```bash
+python tools/validate_build.py   # after build.py; exits 1 and lists every problem
+```
+Checks the four built manifests (version, **permission drift**, no `"tabs"`,
+Firefox gecko id), 43 locales with parseable `messages.json`, no unresolved
+`__PLACEHOLDER__`, and that each ZIP has a root manifest, `_locales`, and no
+`tools/`/`Marketing/`/`tests/` files. Run by CI's `build` job.
 The build copies `src/` then overlays `extensions/<name>/` into
 `dist/<name>/{chrome,firefox}`, patches the manifest + locales for Firefox, and
 emits versioned `.zip` files. `dist/` is gitignored.
@@ -140,6 +149,11 @@ CodeQL *default setup*, configured on GitHub with no workflow file; `python` was
 added to the required list on 09/08/2026, CodeQL having started scanning
 `build.py` and the `tools/` scripts). Branch protection also requires **1
 approving review**, which a solo maintainer cannot self-provide.
+
+`.github/workflows/test.yml` now also runs a **`build`** job (package both
+extensions for both browsers, then `tools/validate_build.py`, then fail if the
+build dirtied a tracked file). It is **not yet in the required list** — add it in
+the GitHub branch-protection settings to make packaging regressions blocking.
 
 Standard flow (the `--admin` on merge overrides *only* the impossible self-review;
 the 4 checks still gate the change):

--- a/build.py
+++ b/build.py
@@ -136,12 +136,22 @@ def _node_env():
     return env
 
 
-def run_tests(assume_yes=False):
-    """Runs Jest. Returns True if tests pass or the user chooses to continue."""
+def run_tests(assume_yes=False, force=False):
+    """Runs Jest. Returns True if tests pass or the user chooses to continue.
 
-    def confirm(question):
-        # Never block on input() when there's no TTY (CI). --yes forces a
-        # "continue anyway"; otherwise fail safe and abort the build.
+    --yes only answers "is it OK to keep going without a TTY" questions. It does
+    NOT wave through a red suite: that used to mean a green "Build finished"
+    was no evidence the tests passed, which is exactly backwards for the flag
+    every automated invocation uses. Overriding a failing suite now takes the
+    explicit --force, whose name says what it does.
+    """
+
+    def confirm(question, overridable=True):
+        if overridable and force:
+            print(f"   {question} -> yes (--force)")
+            return True
+        if not overridable:
+            return False
         if assume_yes:
             print(f"   {question} -> yes (--yes)")
             return True
@@ -177,8 +187,15 @@ def run_tests(assume_yes=False):
         print("✅ All tests passed.\n")
         return True
 
+    # A red suite is fail-closed: only --force (or an interactive "yes") gets past.
     print("\n⚠️  Some tests failed.")
-    return confirm("Continue with the build anyway?")
+    if force:
+        print("   Continuing anyway (--force).")
+        return True
+    if not sys.stdin.isatty():
+        print("   Aborting. Re-run with --force to build on a failing suite.")
+        return False
+    return input("   Continue with the build anyway? [y/N] ").strip().lower() in ("y", "yes")
 
 
 # ---------------------------------------------------------------------------
@@ -436,7 +453,12 @@ def main():
     parser.add_argument(
         "--yes", "-y",
         action="store_true",
-        help="Non-interactive: continue the build even if tests or npm install fail",
+        help="Non-interactive: do not prompt (does NOT override a failing test suite)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Build even if the test suite fails. Use deliberately, never in automation.",
     )
     args = parser.parse_args()
 
@@ -470,7 +492,7 @@ def main():
         primary_version = json.load(f).get("version", "unknown")
     sync_package_version(primary_version)
 
-    if not run_tests(assume_yes=args.yes):
+    if not run_tests(assume_yes=args.yes, force=args.force):
         print("🛑 Build cancelled.")
         sys.exit(1)
 

--- a/tools/validate_build.py
+++ b/tools/validate_build.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Validates the built extensions in dist/.
+
+CI ran `npm test` and nothing else, so a regression in build.py — a dropped
+file, a permission that drifted, an unresolved placeholder — could only be
+caught by hand at release time. This runs after `python build.py` and checks
+the artifacts themselves.
+
+Maintainer tooling: not shipped inside either extension.
+
+Usage:  python tools/validate_build.py
+Exit:   0 when every check passes, 1 otherwise (with each failure listed).
+"""
+
+import json
+import os
+import re
+import sys
+import zipfile
+
+DIST = "dist"
+EXTENSIONS = ["ai-folders", "gemini-folders"]
+BROWSERS = ["chrome", "firefox"]
+EXPECTED_LOCALES = 43
+
+failures = []
+
+
+def fail(msg):
+    failures.append(msg)
+
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def check_manifest(ext, browser):
+    """The built manifest must match its source in the ways that matter."""
+    built_path = os.path.join(DIST, ext, browser, "manifest.json")
+    if not os.path.isfile(built_path):
+        fail(f"{ext}/{browser}: manifest.json missing")
+        return None
+
+    built = load_json(built_path)
+    source = load_json(os.path.join("extensions", ext, "manifest.json"))
+
+    if built.get("version") != source.get("version"):
+        fail(f"{ext}/{browser}: version {built.get('version')} != source {source.get('version')}")
+
+    # Permission drift is the one manifest change that re-prompts every installed
+    # user, so it must never happen as a side effect of a build change.
+    for key in ("permissions", "optional_permissions", "host_permissions"):
+        if sorted(built.get(key) or []) != sorted(source.get(key) or []):
+            fail(f"{ext}/{browser}: {key} drifted from the source manifest")
+
+    if "tabs" in (built.get("permissions") or []):
+        fail(f"{ext}/{browser}: the \"tabs\" permission is present — see CLAUDE.md §7")
+
+    if browser == "firefox":
+        gecko = (built.get("browser_specific_settings") or {}).get("gecko") or {}
+        if not gecko.get("id"):
+            fail(f"{ext}/firefox: browser_specific_settings.gecko.id missing")
+
+    return built
+
+
+def check_locales(ext, browser):
+    loc_dir = os.path.join(DIST, ext, browser, "_locales")
+    if not os.path.isdir(loc_dir):
+        fail(f"{ext}/{browser}: _locales missing")
+        return
+    locales = [d for d in os.listdir(loc_dir) if os.path.isdir(os.path.join(loc_dir, d))]
+    if len(locales) != EXPECTED_LOCALES:
+        fail(f"{ext}/{browser}: {len(locales)} locales, expected {EXPECTED_LOCALES}")
+    for loc in locales:
+        path = os.path.join(loc_dir, loc, "messages.json")
+        try:
+            load_json(path)
+        except Exception as e:
+            fail(f"{ext}/{browser}/_locales/{loc}: unreadable messages.json ({e})")
+
+
+# Build-time substitutions look like __NAME__. One left behind ships literally.
+PLACEHOLDER = re.compile(r"__[A-Z][A-Z0-9_]{3,}__")
+TEXT_EXT = (".json", ".js", ".html", ".css", ".txt")
+
+
+def check_placeholders(ext, browser):
+    root = os.path.join(DIST, ext, browser)
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            if not name.endswith(TEXT_EXT):
+                continue
+            path = os.path.join(dirpath, name)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    content = f.read()
+            except (UnicodeDecodeError, OSError):
+                continue
+            for hit in set(PLACEHOLDER.findall(content)):
+                # The prompt-trigger content script sets its own guard flag.
+                if hit == "__PROMPT_TRIGGER_ACTIVE__":
+                    continue
+                fail(f"{ext}/{browser}/{os.path.relpath(path, root)}: unresolved {hit}")
+
+
+def check_zip(ext, version):
+    """The shipped archive must carry the extension and nothing else."""
+    for browser in BROWSERS:
+        name = os.path.join(DIST, f"{ext}-{browser}-v{version}.zip")
+        if not os.path.isfile(name):
+            fail(f"{ext}: {os.path.basename(name)} not produced")
+            continue
+        with zipfile.ZipFile(name) as z:
+            names = z.namelist()
+        if "manifest.json" not in names:
+            fail(f"{os.path.basename(name)}: no manifest.json at the root")
+        leaked = [n for n in names if n.startswith(("tools/", "Marketing/", "tests/"))]
+        if leaked:
+            fail(f"{os.path.basename(name)}: ships maintainer files, e.g. {leaked[0]}")
+        if not any(n.startswith("_locales/") for n in names):
+            fail(f"{os.path.basename(name)}: no _locales")
+
+
+def main():
+    if not os.path.isdir(DIST):
+        print("❌ dist/ not found — run `python build.py` first.")
+        return 1
+
+    for ext in EXTENSIONS:
+        version = None
+        for browser in BROWSERS:
+            built = check_manifest(ext, browser)
+            if built and version is None:
+                version = built.get("version")
+            check_locales(ext, browser)
+            check_placeholders(ext, browser)
+        if version:
+            check_zip(ext, version)
+
+    # build.py stamps package.json from the Gemini Folders manifest.
+    if os.path.isfile("package.json"):
+        pkg = load_json("package.json").get("version")
+        gf = load_json(os.path.join("extensions", "gemini-folders", "manifest.json")).get("version")
+        if pkg != gf:
+            fail(f"package.json v{pkg} != gemini-folders manifest v{gf}")
+
+    if failures:
+        print(f"❌ {len(failures)} problem(s) with the build:")
+        for f in failures:
+            print(f"   - {f}")
+        return 1
+
+    print("✅ Build artifacts validated: manifests, permissions, locales, placeholders, archives.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Finding 8 of the external audit. Two halves of the same gap: nothing automated actually verified that the extensions still build.

## `build.py` was fail-open

`--yes` answered *"continue with the build anyway?"* for a **failing test suite**, so a green `🎉 Build finished` was no evidence the tests passed — backwards for the flag every automated invocation uses. (I hit this for real earlier in this batch: a build reported success on top of a red test.)

`--yes` now only suppresses prompts. Overriding a red suite takes the explicit **`--force`**, whose name says what it does.

Verified by planting a deliberately failing test:

```
--yes    → ⚠️  Some tests failed.
           Aborting. Re-run with --force to build on a failing suite.
           🛑 Build cancelled.
--force  → Continuing anyway (--force).
           🎉 Build finished successfully!
```

## CI never built anything

`test.yml` ran `npm ci` and `npm test`, full stop. A regression in `build.py` — a dropped file, a permission that drifted, an unresolved placeholder — could only be caught by hand at release time.

New **`build`** job: packages both extensions for both browsers, runs the new validator, then fails if the build dirtied a tracked file (`build.py` stamps `package.json` from the manifest, so a diff there means the committed versions were out of sync). Since `build.py` re-runs Jest, this job also continuously proves the gate still blocks a red suite.

## `tools/validate_build.py`

Maintainer tooling, not shipped. Checks the artifacts themselves:

- the four built manifests: version matches source, **permissions have not drifted**, no `"tabs"` (the permission CLAUDE.md §7 forbids — it re-prompts every installed user), Firefox has its `gecko.id`;
- 43 locales per build, each with a parseable `messages.json`;
- no unresolved `__PLACEHOLDER__` in any shipped text file;
- each ZIP has a root `manifest.json`, has `_locales`, and ships no `tools/`, `Marketing/` or `tests/` files.

**Verified it catches real damage**, not just passes: injecting `"tabs"`, deleting `_locales/fr/messages.json` and planting `__AF_STORE_URL__` produced four precise failures and exit 1; a clean rebuild returns to green.

## Action needed from you

The `build` job is **not yet in the required-checks list** — that has to be set in the GitHub branch-protection settings, alongside `test` and the three `Analyze` checks. Until then it runs but does not block. Noted in CLAUDE.md §4.

`npx jest` — 617 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)