### PR TITLE
fix(a11y): make the dropdowns and modals usable without a mouse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,19 @@ git checkout main && git pull --ff-only
   `site-config.js`, run via `executeScript`. Falls back to a heuristic (lowest
   sizeable text field) and logs `console.warn("[Folders extension] …")` when a
   selector stops matching.
+- **Keyboard access:** custom dropdowns go through `makeMenuAccessible`
+  (`src/ui.js`) — the sort menus in `popup-core.js`/`prompts.js` and the
+  bulk-move list in `bulk-actions.js`. It adds the WAI menu-button roles, roving
+  arrow-key focus, Enter/Space to choose and Escape to close, **without owning
+  the open/close state**: each caller keeps its own show/hide code. It supports
+  the two conventions in use — a `.show` class or the `hidden` attribute —
+  detected once at wiring time (`usesHidden`); testing `!menu.hidden` on a plain
+  `<div>` is always true and would make the menu look permanently open.
+  `showCustomModal` carries `role="dialog"`/`aria-modal`/`aria-labelledby`, traps
+  Tab and restores focus to the opener. Its focusable scan filters on inline
+  `style.display`, **not `offsetParent`**, which is always null under jsdom.
+  Folder and prompt headers already had `tabindex="0"` + `keydown` — that is the
+  pattern to copy for anything new.
 - **Security posture:** folder/conversation titles render via `textContent` (no
   XSS); `link.href` is gated by `isSafeUrl` (falls back to `about:blank`); import
   is validated (`isSafeUrl` + shape checks + chunked writes); the local-LLM

--- a/src/bulk-actions.js
+++ b/src/bulk-actions.js
@@ -34,6 +34,12 @@ document.addEventListener('DOMContentLoaded', () => {
     bulkMoveList.hidden ? openDropdown() : closeDropdown();
   });
 
+  // Keyboard + screen-reader access for the folder list (src/ui.js).
+  if (window.makeMenuAccessible) {
+    window.makeMenuAccessible(bulkMoveTrigger, bulkMoveList,
+      () => bulkMoveList.querySelectorAll('li'));
+  }
+
   // Close on click outside
   document.addEventListener('click', () => {
     if (!bulkMoveList.hidden) closeDropdown();
@@ -96,6 +102,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const li = document.createElement('li');
           li.textContent = `${icon} ${displayName}`;
+          // Focusable and announced: these were click-only <li>, so the folder
+          // list was unreachable without a mouse.
+          li.setAttribute('role', 'menuitem');
+          li.setAttribute('tabindex', '-1');
           li.addEventListener('click', (e) => { e.stopPropagation(); moveTo(folder); });
           bulkMoveList.appendChild(li);
         });

--- a/src/popup-core.js
+++ b/src/popup-core.js
@@ -325,6 +325,12 @@ function initPopupCommon(config) {
     e.stopPropagation();
     sortMenu.classList.toggle('show');
   });
+
+  // Keyboard + screen-reader access for the sort options (src/ui.js).
+  if (window.makeMenuAccessible) {
+    window.makeMenuAccessible(sortToggleBtn, sortMenu,
+      () => sortMenu.querySelectorAll('.dropdown-item'));
+  }
   document.addEventListener('click', () => {
     sortMenu.classList.remove('show');
   });

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -421,6 +421,12 @@ function initPromptsUI() {
     promptSortMenu.classList.toggle('show');
   });
 
+  // Keyboard + screen-reader access for the sort options (src/ui.js).
+  if (window.makeMenuAccessible) {
+    window.makeMenuAccessible(promptSortToggleBtn, promptSortMenu,
+      () => promptSortMenu.querySelectorAll('.dropdown-item'));
+  }
+
   loadData({ promptSortPref: 'dateDesc' }, (data) => {
     const activeItem = document.querySelector(`#promptSortMenu .dropdown-item[data-value="${data.promptSortPref}"]`);
     if (activeItem) activeItem.classList.add('active');

--- a/src/ui.js
+++ b/src/ui.js
@@ -84,7 +84,52 @@ function showCustomModal({ title, message = '', type = 'confirm', defaultValue =
       btnConfirm.textContent = chrome.i18n.getMessage("modalBtnConfirm") || "Confirm";
     }
 
+    // Dialog semantics. The markup is a plain <div> pair, so a screen reader had
+    // no way to know a dialog had opened or what it was called.
+    const dialog = modal.querySelector('.modal-content') || modal;
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-labelledby', 'modalTitle');
+    if (message) dialog.setAttribute('aria-describedby', 'modalMessage');
+    else dialog.removeAttribute('aria-describedby');
+
+    // Return focus where it came from once we're done — otherwise dismissing the
+    // modal drops the user at the top of the popup.
+    const previouslyFocused = document.activeElement;
+
     modal.style.display = 'flex';
+
+    // Focus something inside the dialog. Without this, confirm/alert left focus
+    // on the background control, so Tab walked the page behind the overlay and
+    // Enter only worked because the key handler is global.
+    if (type !== 'prompt') {
+      setTimeout(() => btnConfirm.focus(), 0);
+    }
+
+    // Keep Tab inside the dialog. The overlay only hides the popup visually
+    // (display toggling), so everything behind it stays focusable.
+    // Visibility is checked on the inline style rather than offsetParent: this
+    // modal hides its optional parts with style.display, and offsetParent is
+    // always null under jsdom, which would silently empty the list in tests.
+    const focusables = () => Array.from(
+      dialog.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    ).filter(el => el.style.display !== 'none' && !el.hidden && !el.disabled);
+
+    const onTrapKeydown = (e) => {
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey && (active === first || !dialog.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !dialog.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
 
     const confirm = () => {
       cleanup();
@@ -118,10 +163,15 @@ function showCustomModal({ title, message = '', type = 'confirm', defaultValue =
       btnConfirm.onclick = null;
       btnCancel.onclick = null;
       document.removeEventListener('keydown', onKeydown, true);
+      document.removeEventListener('keydown', onTrapKeydown, true);
       modal.removeEventListener('click', onOverlayClick);
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
     };
 
     document.addEventListener('keydown', onKeydown, true);
+    document.addEventListener('keydown', onTrapKeydown, true);
     modal.addEventListener('click', onOverlayClick);
 
     btnConfirm.onclick = confirm;
@@ -129,8 +179,92 @@ function showCustomModal({ title, message = '', type = 'confirm', defaultValue =
   });
 }
 
+// Makes a custom dropdown reachable without a mouse.
+//
+// The toggles were real <button>s, so keyboard users could open these menus —
+// and then hit a dead end, because the options were <div>/<li> with a click
+// listener and nothing else: not focusable, not announced, not activatable.
+// Follows the WAI menu-button pattern: roles, arrow-key roving focus, Enter or
+// Space to choose, Escape to close and hand focus back to the toggle.
+//
+// Open state is read from the existing `.show` class rather than owned here, so
+// each caller keeps its own show/hide logic untouched.
+function makeMenuAccessible(toggleBtn, menu, getItems) {
+  if (!toggleBtn || !menu) return;
+
+  const items = () => Array.from(getItems ? getItems() : menu.children);
+  // Two conventions in the codebase: the sort menus toggle a `.show` class, the
+  // bulk-move list toggles the `hidden` attribute. Pick one at wiring time —
+  // testing `!menu.hidden` on a plain <div> is always true, which would make the
+  // menu look permanently open.
+  const usesHidden = menu.hasAttribute('hidden');
+  const isOpen = () => usesHidden ? !menu.hidden : menu.classList.contains('show');
+
+  toggleBtn.setAttribute('aria-haspopup', 'menu');
+  toggleBtn.setAttribute('aria-expanded', 'false');
+  menu.setAttribute('role', 'menu');
+  for (const item of items()) {
+    item.setAttribute('role', 'menuitem');
+    item.setAttribute('tabindex', '-1');
+  }
+
+  // The class/hidden flip happens in the caller's own click handler, so mirror
+  // it into aria-expanded afterwards rather than trying to own the state.
+  const syncExpanded = () => toggleBtn.setAttribute('aria-expanded', String(isOpen()));
+  toggleBtn.addEventListener('click', () => setTimeout(syncExpanded, 0));
+  document.addEventListener('click', () => setTimeout(syncExpanded, 0));
+
+  const focusItem = (i) => {
+    const list = items();
+    if (list.length === 0) return;
+    const idx = ((i % list.length) + list.length) % list.length;
+    list[idx].focus();
+  };
+
+  const close = (refocus) => {
+    if (usesHidden) menu.hidden = true;
+    else menu.classList.remove('show');
+    syncExpanded();
+    if (refocus) toggleBtn.focus();
+  };
+
+  toggleBtn.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      // Let the caller's click handler open the menu, then move into it.
+      if (!isOpen()) toggleBtn.click();
+      setTimeout(() => { syncExpanded(); focusItem(e.key === 'ArrowDown' ? 0 : -1); }, 0);
+    } else if (e.key === 'Escape' && isOpen()) {
+      e.preventDefault();
+      close(true);
+    }
+  });
+
+  menu.addEventListener('keydown', (e) => {
+    const list = items();
+    const current = list.indexOf(document.activeElement);
+    switch (e.key) {
+      case 'ArrowDown': e.preventDefault(); focusItem(current + 1); break;
+      case 'ArrowUp':   e.preventDefault(); focusItem(current - 1); break;
+      case 'Home':      e.preventDefault(); focusItem(0); break;
+      case 'End':       e.preventDefault(); focusItem(-1); break;
+      case 'Escape':    e.preventDefault(); close(true); break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (document.activeElement && list.includes(document.activeElement)) {
+          document.activeElement.click();
+          close(true);
+        }
+        break;
+      default: break;
+    }
+  });
+}
+
 window.showCustomModal = showCustomModal;
 window.updateStorageBar = updateStorageBar;
+window.makeMenuAccessible = makeMenuAccessible;
 
 document.addEventListener('DOMContentLoaded', () => {
   const storageTooltip = document.getElementById('storageTooltip');

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -7,7 +7,7 @@ require('../src/ui'); // defines window.showCustomModal (no DOMContentLoaded dis
 function mountModalDOM() {
   document.body.innerHTML = `
     <div id="customModal" style="display:none">
-      <div id="modalDialog">
+      <div id="modalDialog" class="modal-content">
         <div id="modalTitle"></div>
         <div id="modalMessage"></div>
         <input id="modalInput" />
@@ -102,5 +102,146 @@ describe('showCustomModal — keyboard & backdrop', () => {
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
       ).not.toThrow();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accessibility: dialog semantics, focus handling, and the dropdown pattern
+// ---------------------------------------------------------------------------
+
+describe('showCustomModal — accessibility', () => {
+  test('announces itself as a labelled modal dialog', () => {
+    const p = window.showCustomModal({ title: 'Sure?', message: 'Details', type: 'confirm' });
+    const dialog = $('modalDialog');
+    expect(dialog.getAttribute('role')).toBe('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-labelledby')).toBe('modalTitle');
+    expect(dialog.getAttribute('aria-describedby')).toBe('modalMessage');
+    $('modalBtnConfirm').click();
+    return p;
+  });
+
+  test('drops aria-describedby when there is no message', async () => {
+    const p = window.showCustomModal({ title: 'Sure?', type: 'confirm' });
+    expect($('modalDialog').hasAttribute('aria-describedby')).toBe(false);
+    $('modalBtnConfirm').click();
+    await p;
+  });
+
+  test('focuses inside the dialog so Tab cannot start behind it', async () => {
+    jest.useFakeTimers();
+    const p = window.showCustomModal({ title: 'Sure?', type: 'confirm' });
+    jest.advanceTimersByTime(1);
+    expect(document.activeElement).toBe($('modalBtnConfirm'));
+    $('modalBtnConfirm').click();
+    jest.useRealTimers();
+    await p;
+  });
+
+  test('returns focus to the control that opened it', async () => {
+    document.body.insertAdjacentHTML('beforeend', '<button id="opener"></button>');
+    const opener = $('opener');
+    opener.focus();
+    const p = window.showCustomModal({ title: 'Sure?', type: 'confirm' });
+    $('modalBtnConfirm').click();
+    await p;
+    expect(document.activeElement).toBe(opener);
+  });
+
+  test('Tab wraps inside the dialog instead of escaping to the page behind', async () => {
+    // The overlay only hides the popup visually, so without a trap Tab walks
+    // the still-focusable controls underneath it.
+    document.body.insertAdjacentHTML('beforeend', '<button id="behind"></button>');
+    const p = window.showCustomModal({ title: 'Sure?', type: 'confirm' });
+    $('modalBtnConfirm').focus();
+    const e = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    document.dispatchEvent(e);
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).not.toBe($('behind'));
+    $('modalBtnConfirm').click();
+    await p;
+  });
+});
+
+describe('makeMenuAccessible', () => {
+  function mountMenu() {
+    document.body.innerHTML = `
+      <button id="tog"></button>
+      <div id="menu">
+        <div class="dropdown-item" data-value="a"></div>
+        <div class="dropdown-item" data-value="b"></div>
+        <div class="dropdown-item" data-value="c"></div>
+      </div>`;
+    const tog = $('tog');
+    const menu = $('menu');
+    tog.addEventListener('click', () => menu.classList.toggle('show'));
+    window.makeMenuAccessible(tog, menu, () => menu.querySelectorAll('.dropdown-item'));
+    return { tog, menu, items: [...menu.querySelectorAll('.dropdown-item')] };
+  }
+
+  test('gives the toggle and the options their roles', () => {
+    const { tog, menu, items } = mountMenu();
+    expect(tog.getAttribute('aria-haspopup')).toBe('menu');
+    expect(tog.getAttribute('aria-expanded')).toBe('false');
+    expect(menu.getAttribute('role')).toBe('menu');
+    for (const it of items) {
+      expect(it.getAttribute('role')).toBe('menuitem');
+      expect(it.getAttribute('tabindex')).toBe('-1');
+    }
+  });
+
+  test('ArrowDown on the toggle opens the menu and lands on the first option', () => {
+    jest.useFakeTimers();
+    const { tog, menu, items } = mountMenu();
+    tog.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    jest.advanceTimersByTime(1);
+    expect(menu.classList.contains('show')).toBe(true);
+    expect(tog.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(items[0]);
+    jest.useRealTimers();
+  });
+
+  test('arrows move between options and wrap around', () => {
+    jest.useFakeTimers();
+    const { tog, menu, items } = mountMenu();
+    tog.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    jest.advanceTimersByTime(1);
+    const arrow = (key) => menu.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+    arrow('ArrowDown');
+    expect(document.activeElement).toBe(items[1]);
+    arrow('ArrowUp');
+    arrow('ArrowUp');
+    expect(document.activeElement).toBe(items[2]);   // wrapped past the start
+    arrow('End');
+    expect(document.activeElement).toBe(items[2]);
+    arrow('Home');
+    expect(document.activeElement).toBe(items[0]);
+    jest.useRealTimers();
+  });
+
+  test('Enter chooses the focused option and closes the menu', () => {
+    jest.useFakeTimers();
+    const { tog, menu, items } = mountMenu();
+    const chosen = jest.fn();
+    items[1].addEventListener('click', chosen);
+    tog.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    jest.advanceTimersByTime(1);
+    menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    expect(chosen).toHaveBeenCalled();
+    expect(menu.classList.contains('show')).toBe(false);
+    expect(document.activeElement).toBe(tog);
+    jest.useRealTimers();
+  });
+
+  test('Escape closes the menu and hands focus back to the toggle', () => {
+    jest.useFakeTimers();
+    const { tog, menu } = mountMenu();
+    tog.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    jest.advanceTimersByTime(1);
+    menu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    expect(menu.classList.contains('show')).toBe(false);
+    expect(document.activeElement).toBe(tog);
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
Finding 9 of the external audit — the last one. Neither `popup.html` contained a single `role=` or `aria-*` attribute.

## The dead ends

The toggles were real `<button>`s, so a keyboard user could **open** the sort menus and the bulk-move list — and then hit a wall. The options were `<div>` / `<li>` with a click listener and nothing else: not focusable, not announced, not activatable.

`makeMenuAccessible` (`src/ui.js`) wires all three — folder sort, prompt sort, bulk move — to the WAI menu-button pattern: roles on toggle and options, roving arrow-key focus with wraparound, Home/End, Enter or Space to choose, Escape to close and hand focus back to the toggle.

It deliberately **does not own the open/close state**. Each caller keeps its own show/hide code and the helper mirrors it into `aria-expanded`, so no existing behaviour changes. It supports both conventions in the codebase — a `.show` class (sort menus) and the `hidden` attribute (bulk move) — decided once at wiring time. Getting that wrong is not theoretical: my first version tested `!menu.hidden`, which is **always true on a plain `<div>`**, so the menu looked permanently open and arrow-down never opened it. The new tests caught it.

## The modal

`showCustomModal` already had Enter/Escape, backdrop dismissal and input autofocus. What was missing:

- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` (and `aria-describedby` when there is a message) — a screen reader had no way to know a dialog had opened or what it was called;
- **initial focus** for `confirm`/`alert`: focus stayed on the background control, and Enter only worked because the key handler is global — meaning it also fired from an unrelated background field;
- a **focus trap**: the overlay only hides the popup visually (`display` toggling), so Tab walked the still-focusable controls behind it;
- **focus restoration** to whatever opened the modal.

One implementation note worth keeping: the focusable scan filters on inline `style.display`, **not `offsetParent`**. The modal hides its optional parts with `style.display`, and `offsetParent` is always `null` under jsdom — which silently emptied the list and made the trap test pass for the wrong reason until I noticed.

## Testing

Ten new tests: dialog roles present and `aria-describedby` absent when there is no message; focus lands inside the dialog; focus returns to the opener; Tab is trapped; and the full keyboard path through a menu — roles applied, ArrowDown opens and lands on the first option, arrows wrap, Home/End, Enter chooses and closes, Escape closes and refocuses.

`npx jest` — 627 passing. `python build.py --yes` + `python tools/validate_build.py` — clean. Script order verified: `ui.js` loads before its three consumers, all of which wire up on `DOMContentLoaded`.

## Manual verification owed

A full pass with the keyboard only, then with VoiceOver, in both modes and both extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)