### PR TITLE
fix: close the six defects the follow-up audit found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,9 +116,10 @@ python build.py          # interactive
 python build.py --yes    # non-interactive (also -y); use this in automation
 python build.py --force  # build anyway on a red suite — deliberate use only
 ```
-`--yes` only suppresses prompts; it does **not** wave through failing tests
-(it used to, which meant a green `🎉 Build finished` proved nothing). Overriding
-a red suite now takes the explicit `--force`.
+`--yes` only suppresses prompts; it does **not** wave through a test gate that
+did not pass (it used to, which meant a green `🎉 Build finished` proved nothing).
+That covers **both** a red suite and a suite that could not be executed at all —
+the second case tells you even less than the first. Only `--force` continues.
 
 **Validate what was built:**
 ```bash
@@ -203,13 +204,16 @@ git checkout main && git pull --ff-only
   `scrollbar-gutter` in `popup.css` without a separate reason.
 - **Data is keyed by folder name and conversation URL** (no stable IDs). Renames,
   pins and migrations are awkward by design (see TODO §8). Because those keys are
-  user-typed names on ordinary objects, **every creation and rename path must
-  reject `isUnsafeKey` names** (`__proto__`, `constructor`, `prototype` —
-  `src/utils.js`, shown to the user as `reservedNameError`). `folders['__proto__']`
-  is `Object.prototype`: truthy, so the "create if missing" guard is skipped and
-  the next `.some()` throws; `prompts['__proto__'] = {…}` hits the prototype setter
-  so the prompt is never created and `JSON.stringify` emits `{}`. `moveChat` needs
-  no guard — its target comes from folders that can no longer be created.
+  user-typed names on ordinary objects, **every existence check must go through
+  `hasEntry(container, name)`** (`src/utils.js`), never plain truthiness.
+  `folders[name]` is truthy for *every* member of `Object.prototype`, so a folder
+  called `toString` or `valueOf` skipped its "create if missing" guard and then
+  threw on `.some()` — a blacklist can never be complete, which is why the old
+  three-name `isUnsafeKey` was the wrong shape of fix. With an ownership test
+  those names simply work as ordinary titles. `isUnsafeKey` now rejects exactly
+  one name, `__proto__`: assigning it invokes the prototype setter instead of
+  creating a property, so the entry is never stored and `JSON.stringify` emits
+  `{}`. Rejection is surfaced as `reservedNameError`.
 - **Marketing screenshots** are regenerated only at release time
   (`python build_images.py`), not on every change.
 
@@ -270,12 +274,29 @@ git checkout main && git pull --ff-only
   the open/close state**: each caller keeps its own show/hide code. It supports
   the two conventions in use — a `.show` class or the `hidden` attribute —
   detected once at wiring time (`usesHidden`); testing `!menu.hidden` on a plain
-  `<div>` is always true and would make the menu look permanently open.
+  `<div>` is always true and would make the menu look permanently open. Pass
+  `{ radio: true }` for a single-choice menu (both sort menus): items become
+  `menuitemradio` and `aria-checked` tracks the `.active` class via a
+  MutationObserver, because that class is applied asynchronously by `loadData`.
+  `aria-expanded` is re-synced from a **capture** listener on the menu — the
+  bulk-move `<li>` stops propagation, so a bubble listener never sees the click.
+  Keyboard-opened menus move focus to the first item, detected with
+  `e.detail === 0`; `preventDefault` is not usable there since it would suppress
+  the very click that opens the menu.
   `showCustomModal` carries `role="dialog"`/`aria-modal`/`aria-labelledby`, traps
   Tab and restores focus to the opener. Its focusable scan filters on inline
   `style.display`, **not `offsetParent`**, which is always null under jsdom.
   Folder and prompt headers already had `tabindex="0"` + `keydown` — that is the
   pattern to copy for anything new.
+- **Prompt autosave:** inline edits go through one module-level slot committed by
+  `flushPendingEdit` (`src/prompts.js`), called on blur, on `pagehide`, before
+  rename/delete/pin and at the top of `displayPrompts`. **Its callback must not
+  run until every queued commit has finished writing** — commits are serialized on
+  a promise chain, because clearing the slot is synchronous while the load/save
+  that follows is not: blur then Pin used to let Pin read the pre-edit text and
+  save it back over the edit. Callers with nothing pending still get a synchronous
+  callback, so re-renders are unaffected. Tests must use genuinely async storage
+  mocks to see this; the synchronous ones hide every ordering bug.
 - **Security posture:** folder/conversation titles render via `textContent` (no
   XSS); `link.href` is gated by `isSafeUrl` (falls back to `about:blank`); import
   is validated (`isSafeUrl` + shape checks + chunked writes); the local-LLM

--- a/build.py
+++ b/build.py
@@ -146,17 +146,20 @@ def run_tests(assume_yes=False, force=False):
     explicit --force, whose name says what it does.
     """
 
-    def confirm(question, overridable=True):
-        if overridable and force:
+    def confirm(question):
+        """Only --force (or a human typing yes) may continue past a failure.
+
+        --yes means "don't prompt me", not "ship it regardless": answering yes on
+        its behalf is what made a green 'Build finished' meaningless. Every
+        question here is about a test gate that did not pass — including the case
+        where the suite could not be executed at all, which tells us even less
+        than a red suite does.
+        """
+        if force:
             print(f"   {question} -> yes (--force)")
             return True
-        if not overridable:
-            return False
-        if assume_yes:
-            print(f"   {question} -> yes (--yes)")
-            return True
-        if not sys.stdin.isatty():
-            print(f"   {question} -> no (non-interactive, aborting)")
+        if assume_yes or not sys.stdin.isatty():
+            print(f"   {question} -> no. Re-run with --force to build anyway.")
             return False
         return input(f"   {question} [y/N] ").strip().lower() in ("y", "yes")
 
@@ -189,13 +192,7 @@ def run_tests(assume_yes=False, force=False):
 
     # A red suite is fail-closed: only --force (or an interactive "yes") gets past.
     print("\n⚠️  Some tests failed.")
-    if force:
-        print("   Continuing anyway (--force).")
-        return True
-    if not sys.stdin.isatty():
-        print("   Aborting. Re-run with --force to build on a failing suite.")
-        return False
-    return input("   Continue with the build anyway? [y/N] ").strip().lower() in ("y", "yes")
+    return confirm("Continue with the build anyway?")
 
 
 # ---------------------------------------------------------------------------

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -488,7 +488,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
     const data = await new Promise(resolve => loadData({ folders: {} }, resolve));
     let folders = data.folders || {};
-    if (!folders[targetFolder]) folders[targetFolder] = [];
+    if (!hasEntry(folders, targetFolder)) folders[targetFolder] = [];
 
     const cleanTargetUrl = normalizeUrl(tab.url);
     const isDuplicate = folders[targetFolder].some(chat => normalizeUrl(chat.url) === cleanTargetUrl);
@@ -547,7 +547,7 @@ chrome.commands.onCommand.addListener(async (command) => {
 
     const data = await new Promise(resolve => loadData({ folders: {} }, resolve));
     let folders = data.folders || {};
-    if (!folders[targetFolder]) folders[targetFolder] = [];
+    if (!hasEntry(folders, targetFolder)) folders[targetFolder] = [];
 
     const cleanTargetUrl = normalizeUrl(tab.url);
     const isDuplicate = folders[targetFolder].some(chat => normalizeUrl(chat.url) === cleanTargetUrl);

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -197,7 +197,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       const data = await new Promise(resolve => loadData({ folders: {} }, resolve));
       let folders = data.folders || {};
 
-      if (!folders[targetFolder]) folders[targetFolder] = [];
+      if (!hasEntry(folders, targetFolder)) folders[targetFolder] = [];
       const cleanTargetUrl = normalizeUrl(tab.url);
       const isDuplicate = folders[targetFolder].some(chat => normalizeUrl(chat.url) === cleanTargetUrl);
       if (!isDuplicate) {
@@ -402,7 +402,7 @@ chrome.commands.onCommand.addListener(async (command) => {
       const data = await new Promise(resolve => loadData({ folders: {} }, resolve));
 
       let folders = data.folders || {};
-      if (!folders[targetFolder]) folders[targetFolder] = [];
+      if (!hasEntry(folders, targetFolder)) folders[targetFolder] = [];
 
       const cleanTargetUrl = normalizeUrl(tab.url);
       const isDuplicate = folders[targetFolder].some(chat => normalizeUrl(chat.url) === cleanTargetUrl);

--- a/src/bulk-actions.js
+++ b/src/bulk-actions.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
       let folders    = data.folders;
       let openFolders = data.openFolders;
 
-      if (!folders[targetFolder]) folders[targetFolder] = [];
+      if (!hasEntry(folders, targetFolder)) folders[targetFolder] = [];
 
       window.selectedChats.forEach(item => {
         if (folders[item.folder]) {

--- a/src/folders.js
+++ b/src/folders.js
@@ -430,7 +430,7 @@ function moveChat(sourceFolder, targetFolder, chatUrl) {
     const chatToMove = folders[sourceFolder].splice(realIndex, 1)[0];
 
     // Ensure target folder exists
-    if (!folders[targetFolder]) folders[targetFolder] = [];
+    if (!hasEntry(folders, targetFolder)) folders[targetFolder] = [];
 
     // Prevent duplicates in target folder
     const cleanTargetUrl = normalizeUrl(chatToMove.url);
@@ -511,7 +511,7 @@ async function renameFolder(oldName) {
     let pinned = data.pinnedFolders;
 
     // Check we are not overwriting another folder
-    if (folders[trimmedNewName]) {
+    if (hasEntry(folders, trimmedNewName)) {
       await window.showCustomModal({
         title: chrome.i18n.getMessage("errorFolderExists") || "A folder with this name already exists.",
         type: 'alert'

--- a/src/popup-core.js
+++ b/src/popup-core.js
@@ -145,7 +145,7 @@ function initSaveConversation(opts) {
 
     loadData({ folders: {} }, (data) => {
       let folders = data.folders;
-      if (!folders[folderName]) folders[folderName] = [];
+      if (!hasEntry(folders, folderName)) folders[folderName] = [];
 
       const cleanTargetUrl = normalizeUrl(chatUrl);
       const isDuplicate = folders[folderName].some(chat => normalizeUrl(chat.url) === cleanTargetUrl);
@@ -261,7 +261,7 @@ function initPopupCommon(config) {
         return;
       }
       loadData({ folders: {} }, (data) => {
-        if (!data.folders[name.trim()]) {
+        if (!hasEntry(data.folders, name.trim())) {
           data.folders[name.trim()] = [];
           saveData({ folders: data.folders }, (err) => {
             if (err) { window.showCustomModal({ title: chrome.i18n.getMessage("storageFullError") || '⚠️ Storage full — not saved.', type: 'alert' }); return; }
@@ -328,8 +328,9 @@ function initPopupCommon(config) {
 
   // Keyboard + screen-reader access for the sort options (src/ui.js).
   if (window.makeMenuAccessible) {
+    // A single-choice group: aria-checked follows the .active class.
     window.makeMenuAccessible(sortToggleBtn, sortMenu,
-      () => sortMenu.querySelectorAll('.dropdown-item'));
+      () => sortMenu.querySelectorAll('.dropdown-item'), { radio: true });
   }
   document.addEventListener('click', () => {
     sortMenu.classList.remove('show');

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -35,29 +35,56 @@ const PROMPT_DELAY = { AUTOSAVE: 600, ICON: 1500 };
 // There is only ever one: editing a second prompt means the first lost focus.
 let _pendingEdit = null;   // { title, text, timer }
 
-// Commits the pending edit, if any, then runs `cb`. Safe to call unconditionally.
-function flushPendingEdit(cb) {
+// Writes still running. Clearing _pendingEdit is synchronous but the load/save
+// that follows is not, so without this a caller that flushed and then read
+// storage could read it *before* the write it just triggered had landed — blur
+// followed by a click on Pin was enough to resurrect the old text.
+let _commitChain = Promise.resolve();
+let _commitsInFlight = 0;
+
+function commitPendingEdit() {
   const pending = _pendingEdit;
-  if (!pending) { if (cb) cb(); return; }
+  if (!pending) return Promise.resolve();
   clearTimeout(pending.timer);
   _pendingEdit = null;
-  loadData({ prompts: {} }, (data) => {
-    // Gone (deleted, or renamed by something that did not flush first).
-    if (!data.prompts[pending.title]) { if (cb) cb(); return; }
-    data.prompts[pending.title].text = pending.text;
-    data.prompts[pending.title].timestamp = Date.now();
-    saveData({ prompts: data.prompts }, (err) => {
-      // The old autosave passed no callback at all, so a full quota lost the
-      // edit without a word.
-      if (err && window.showCustomModal) {
-        window.showCustomModal({
-          title: chrome.i18n.getMessage("storageFullError") || '⚠️ Storage full — not saved.',
-          type: 'alert',
-        });
-      }
-      if (cb) cb();
+  return new Promise((resolve) => {
+    loadData({ prompts: {} }, (data) => {
+      // Gone (deleted, or renamed by something that did not flush first).
+      if (!hasEntry(data.prompts, pending.title)) { resolve(); return; }
+      data.prompts[pending.title].text = pending.text;
+      data.prompts[pending.title].timestamp = Date.now();
+      saveData({ prompts: data.prompts }, (err) => {
+        // The old autosave passed no callback at all, so a full quota lost the
+        // edit without a word.
+        if (err && window.showCustomModal) {
+          window.showCustomModal({
+            title: chrome.i18n.getMessage("storageFullError") || '⚠️ Storage full — not saved.',
+            type: 'alert',
+          });
+        }
+        resolve();
+      });
     });
   });
+}
+
+// Commits the pending edit, if any, then runs `cb`. Safe to call unconditionally.
+//
+// `cb` runs only once every commit already queued has finished writing, so a
+// caller may read storage inside it and be sure of seeing the edit. When there
+// is nothing pending and nothing in flight the callback still runs
+// synchronously — most callers are just re-rendering, and making them all
+// asynchronous would be a needless behaviour change.
+function flushPendingEdit(cb) {
+  const runCb = () => { if (cb) { try { cb(); } catch (e) { console.error(e); } } };
+  if (!_pendingEdit && _commitsInFlight === 0) { runCb(); return; }
+
+  _commitsInFlight++;
+  _commitChain = _commitChain
+    .then(commitPendingEdit)
+    .catch((e) => { console.error('Prompt autosave failed:', e); })
+    .then(() => { _commitsInFlight--; });
+  _commitChain.then(runCb);
 }
 
 function queueEdit(title, text) {
@@ -67,11 +94,28 @@ function queueEdit(title, text) {
   _pendingEdit = { title, text, timer: setTimeout(() => flushPendingEdit(), PROMPT_DELAY.AUTOSAVE) };
 }
 
-// Best-effort save when the popup is dismissed. The document is torn down right
-// after, so the storage call may not complete — but the write is dispatched
-// synchronously here, which is strictly better than losing the edit outright.
+// Last-ditch save when the popup is dismissed. Genuinely best-effort: the write
+// goes through async storage APIs and the document is torn down immediately
+// after, so it may not land. `blur` is the path that actually saves — it fires
+// first whenever focus moves — and this only covers closing the popup with the
+// caret still in the box.
 if (typeof window !== 'undefined' && window.addEventListener) {
   window.addEventListener('pagehide', () => flushPendingEdit());
+}
+
+// Exposed for unit tests only (Node; `module` is undefined in the popup). The
+// autosave state lives for one popup session in production, but a test file
+// shares one module instance across every test — without this, an edit left
+// pending by one test leaks into the next. Same pattern as prompt-trigger.js.
+if (typeof module !== 'undefined') {
+  module.exports = {
+    resetAutosaveState() {
+      if (_pendingEdit) clearTimeout(_pendingEdit.timer);
+      _pendingEdit = null;
+      _commitChain = Promise.resolve();
+      _commitsInFlight = 0;
+    },
+  };
 }
 
 function buildPromptItem(title, p, openPrompts) {
@@ -95,7 +139,7 @@ function buildPromptItem(title, p, openPrompts) {
   pinBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     flushPendingEdit(() => loadData({ prompts: {} }, (data) => {
-      if (data.prompts[title]) {
+      if (hasEntry(data.prompts, title)) {
         data.prompts[title].pinned = !data.prompts[title].pinned;
         saveData({ prompts: data.prompts }, () => displayPrompts());
       }
@@ -153,7 +197,7 @@ function buildPromptItem(title, p, openPrompts) {
     // Commit first: doRename copies the *stored* text, so an unflushed edit
     // would be silently dropped, and the pending title is about to stop existing.
     flushPendingEdit(() => loadData({ prompts: {}, openPrompts: [] }, (data) => {
-      if (data.prompts[trimmed] && trimmed !== title) {
+      if (hasEntry(data.prompts, trimmed) && trimmed !== title) {
         window.showCustomModal({
           title: chrome.i18n.getMessage("promptDuplicateWarning") || "A prompt with this title already exists. Overwrite?",
           type: 'confirm',
@@ -371,7 +415,7 @@ function initPromptsUI() {
     }
 
     loadData({ prompts: {} }, async (data) => {
-      if (data.prompts[title]) {
+      if (hasEntry(data.prompts, title)) {
         const confirmed = await window.showCustomModal({
           title: chrome.i18n.getMessage("promptDuplicateWarning") || "A prompt with this title already exists. Overwrite?",
           type: 'confirm'
@@ -423,8 +467,9 @@ function initPromptsUI() {
 
   // Keyboard + screen-reader access for the sort options (src/ui.js).
   if (window.makeMenuAccessible) {
+    // A single-choice group: aria-checked follows the .active class.
     window.makeMenuAccessible(promptSortToggleBtn, promptSortMenu,
-      () => promptSortMenu.querySelectorAll('.dropdown-item'));
+      () => promptSortMenu.querySelectorAll('.dropdown-item'), { radio: true });
   }
 
   loadData({ promptSortPref: 'dateDesc' }, (data) => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -189,9 +189,17 @@ function showCustomModal({ title, message = '', type = 'confirm', defaultValue =
 //
 // Open state is read from the existing `.show` class rather than owned here, so
 // each caller keeps its own show/hide logic untouched.
-function makeMenuAccessible(toggleBtn, menu, getItems) {
+//
+// options.radio marks the menu as a single-choice group (the sort menus):
+// items become menuitemradio and their aria-checked mirrors options.selectedClass
+// (default 'active'), so a screen reader can tell which ordering is in effect —
+// with role="menuitem" the current choice was visual only.
+function makeMenuAccessible(toggleBtn, menu, getItems, options) {
   if (!toggleBtn || !menu) return;
 
+  const opts = options || {};
+  const isRadioGroup = !!opts.radio;
+  const selectedClass = opts.selectedClass || 'active';
   const items = () => Array.from(getItems ? getItems() : menu.children);
   // Two conventions in the codebase: the sort menus toggle a `.show` class, the
   // bulk-move list toggles the `hidden` attribute. Pick one at wiring time —
@@ -200,12 +208,27 @@ function makeMenuAccessible(toggleBtn, menu, getItems) {
   const usesHidden = menu.hasAttribute('hidden');
   const isOpen = () => usesHidden ? !menu.hidden : menu.classList.contains('show');
 
+  const itemRole = isRadioGroup ? 'menuitemradio' : 'menuitem';
   toggleBtn.setAttribute('aria-haspopup', 'menu');
   toggleBtn.setAttribute('aria-expanded', 'false');
   menu.setAttribute('role', 'menu');
-  for (const item of items()) {
-    item.setAttribute('role', 'menuitem');
-    item.setAttribute('tabindex', '-1');
+  const tagItems = () => {
+    for (const item of items()) {
+      item.setAttribute('role', itemRole);
+      item.setAttribute('tabindex', '-1');
+      if (isRadioGroup) {
+        item.setAttribute('aria-checked', String(item.classList.contains(selectedClass)));
+      }
+    }
+  };
+  tagItems();
+
+  // The selected class is applied asynchronously (loadData) and again on every
+  // choice, so watch for it instead of asking each caller to report it.
+  if (isRadioGroup && typeof MutationObserver !== 'undefined') {
+    new MutationObserver(tagItems).observe(menu, {
+      attributes: true, attributeFilter: ['class'], subtree: true, childList: true,
+    });
   }
 
   // The class/hidden flip happens in the caller's own click handler, so mirror
@@ -213,6 +236,10 @@ function makeMenuAccessible(toggleBtn, menu, getItems) {
   const syncExpanded = () => toggleBtn.setAttribute('aria-expanded', String(isOpen()));
   toggleBtn.addEventListener('click', () => setTimeout(syncExpanded, 0));
   document.addEventListener('click', () => setTimeout(syncExpanded, 0));
+  // Choosing an item closes the menu, but the bulk-move list stops propagation
+  // on its <li> clicks, so the document listener above never sees them and
+  // aria-expanded stayed "true" on a closed menu. Capture fires regardless.
+  menu.addEventListener('click', () => setTimeout(syncExpanded, 0), true);
 
   const focusItem = (i) => {
     const list = items();
@@ -238,6 +265,17 @@ function makeMenuAccessible(toggleBtn, menu, getItems) {
       e.preventDefault();
       close(true);
     }
+  });
+
+  // Enter and Space fire the button's native click, which opens the menu — but
+  // focus stayed on the toggle while every item is tabindex="-1", so the menu
+  // was open with nowhere to go. The WAI pattern puts focus on the first item.
+  // detail === 0 marks a keyboard-generated click, so a real mouse click still
+  // leaves focus alone. preventDefault is not an option here: it would suppress
+  // the very click that opens the menu.
+  toggleBtn.addEventListener('click', (e) => {
+    if (e.detail !== 0) return;
+    setTimeout(() => { if (isOpen()) focusItem(0); }, 0);
   });
 
   menu.addEventListener('keydown', (e) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -398,18 +398,28 @@ function extractTitleLogic(strategies, defaultFallback) {
   return defaultFallback;
 }
 
-// Folders and prompts are keyed by user-typed names on ordinary objects, so a
-// name that collides with something on Object.prototype misbehaves badly:
-// folders["__proto__"] resolves to Object.prototype (truthy, so the "create it
-// if missing" guard is skipped) and the following .some()/.push() throws;
-// prompts["__proto__"] = {...} hits the prototype setter instead of creating a
-// property, so JSON.stringify serializes {} and the prompt disappears.
-// "constructor" behaves the same way.
+// Does this container really hold an entry called `name`?
 //
-// The import path has skipped these since it was hardened; this is the same
-// check, hoisted so creation and rename can reject them at the door too.
+// Folders and prompts are keyed by user-typed names on ordinary objects, so
+// `folders[name]` is truthy for EVERY member of Object.prototype — not just the
+// three that used to be blacklisted here. A folder named "toString", "valueOf"
+// or "hasOwnProperty" therefore skipped its "create it if missing" guard and
+// then threw on `.some()`, wedging the save button exactly like "__proto__"
+// did. Blacklisting was the wrong shape of fix: the list can never be complete.
+//
+// An ownership test is complete, and it also makes those names simply *work* as
+// ordinary folder titles instead of being refused.
+function hasEntry(container, name) {
+  return !!container && Object.prototype.hasOwnProperty.call(container, name);
+}
+
+// The one name an ownership check cannot rescue: assigning to "__proto__" on a
+// plain object invokes the prototype setter instead of creating a property, so
+// the entry is never stored and JSON.stringify emits {} — the folder or prompt
+// silently disappears. Every other inherited name is fine once lookups go
+// through hasEntry, so this is now a list of exactly one.
 function isUnsafeKey(k) {
-  return k === '__proto__' || k === 'constructor' || k === 'prototype';
+  return k === '__proto__';
 }
 
 function isSafeUrl(url) {
@@ -480,7 +490,7 @@ function mergeImportData(importedData) {
       //    array of chats, and validate each chat's shape before storing it.
       for (const [folderName, chats] of Object.entries(foldersToImport)) {
         if (typeof folderName !== 'string' || isUnsafeKey(folderName) || !Array.isArray(chats)) continue;
-        if (!currentFolders[folderName]) currentFolders[folderName] = [];
+        if (!hasEntry(currentFolders, folderName)) currentFolders[folderName] = [];
         chats.forEach(importedChat => {
           if (isPlainObject(importedChat)
               && typeof importedChat.title === 'string'
@@ -926,5 +936,6 @@ if (typeof module !== 'undefined') {
     buildUninstallUrl,
     saveDataAsync,
     isUnsafeKey,
+    hasEntry,
   };
 }

--- a/tests/bulk-actions.test.js
+++ b/tests/bulk-actions.test.js
@@ -6,6 +6,7 @@ const EMOJI_PREFIX_REGEX =
   /^((?:\p{Emoji_Presentation}|\p{Extended_Pictographic})️?)\s*/u;
 
 require('../src/bulk-actions');
+global.hasEntry = require('../src/utils').hasEntry;
 
 function mountDOM() {
   document.body.innerHTML = `

--- a/tests/folders.test.js
+++ b/tests/folders.test.js
@@ -37,6 +37,7 @@ function savedPins() {
 beforeEach(() => {
   global.normalizeUrl = jest.fn((url) => url.split('?')[0].split('#')[0]);
   global.isUnsafeKey = require('../src/utils').isUnsafeKey;
+global.hasEntry = require('../src/utils').hasEntry;
   global.isSafeUrl = jest.fn(() => true);
   global.window.showCustomModal = jest.fn();
   // openConversation closes the popup when it is done; in jsdom the real

--- a/tests/popup-core.test.js
+++ b/tests/popup-core.test.js
@@ -1,6 +1,7 @@
 // popup-core.js shared wiring: the i18n/RTL pass, the cross-browser clearable
 // utils.js is a classic script in the popup, so its helpers are globals there.
 global.isUnsafeKey = require('../src/utils').isUnsafeKey;
+global.hasEntry = require('../src/utils').hasEntry;
 // search control (recent feature), and the "save current conversation" flow.
 
 require('../src/popup-core'); // defines window.applyCommonI18n / setupClearableSearch / initSaveConversation
@@ -202,6 +203,25 @@ describe('initSaveConversation', () => {
 
     expect(global.saveData).toHaveBeenCalled();
   });
+
+  test.each(['toString', 'valueOf', 'hasOwnProperty', 'constructor'])(
+    'saves into a folder named %s like any other', async (name) => {
+      // folders[name] is inherited and truthy for every Object.prototype member,
+      // so the "create it if missing" guard was skipped and the .some() after it
+      // threw. Blacklisting three names could never cover this; the guard is an
+      // ownership test now, which also makes these usable folder titles.
+      chrome.tabs.query = jest.fn().mockResolvedValue([{ url: 'https://claude.ai/chat/1' }]);
+      global.loadData = jest.fn((defaults, cb) => cb({ folders: {} }));
+      wire(() => 'claude');
+
+      document.getElementById('folderName').value = name;
+      document.getElementById('saveBtn').click();
+      await flush();
+
+      expect(global.saveData).toHaveBeenCalled();
+      expect(savedFolders[name]).toHaveLength(1);
+      expect(savedFolders[name][0].url).toBe('https://claude.ai/chat/1');
+    });
 
   test('refuses a reserved folder name instead of wedging the Save button', async () => {
     // folders["__proto__"] is Object.prototype: truthy, so the "create it if

--- a/tests/prompts.test.js
+++ b/tests/prompts.test.js
@@ -2,11 +2,12 @@
 // alpha sort, the live search filter (title + body) and the pinned/unpinned
 // divider. Mirrors the displayFolders coverage in folders.test.js.
 
-require('../src/prompts'); // exposes window.displayPrompts
+const { resetAutosaveState } = require('../src/prompts'); // also exposes window.displayPrompts
 
 // In the popup, utils.js is a classic script loaded first, so its helpers are
 // globals. Jest has no such loader — provide the one prompts.js reaches for.
 global.isUnsafeKey = require('../src/utils').isUnsafeKey;
+global.hasEntry = require('../src/utils').hasEntry;
 
 function setupStorage(prompts, { promptSortPref = 'dateDesc', openPrompts = [] } = {}) {
   global.loadData = jest.fn((defaults, cb) =>
@@ -36,6 +37,22 @@ function setupStatefulStorage(prompts, { openPrompts = [] } = {}) {
   return store;
 }
 
+// Storage with REAL async callbacks. The default mocks resolve synchronously,
+// which hides any ordering bug: a caller could read storage before the write it
+// just triggered had landed and the test would never notice.
+function setupAsyncStorage(prompts, { openPrompts = [] } = {}) {
+  const store = {
+    prompts: JSON.parse(JSON.stringify(prompts)),
+    openPrompts: [...openPrompts],
+    promptSortPref: 'dateDesc',
+  };
+  global.loadData = jest.fn((defaults, cb) =>
+    setTimeout(() => cb(JSON.parse(JSON.stringify(store))), 0));
+  global.saveData = jest.fn((data, cb) =>
+    setTimeout(() => { Object.assign(store, JSON.parse(JSON.stringify(data))); if (cb) cb(); }, 0));
+  return store;
+}
+
 function render(searchValue = '') {
   document.getElementById('promptSearchInput').value = searchValue;
   window.displayPrompts();
@@ -45,7 +62,10 @@ const listEl = () => document.getElementById('promptList');
 const titles = () =>
   [...listEl().querySelectorAll('.prompt-title')].map((el) => el.textContent);
 
+afterEach(() => { jest.useRealTimers(); });
+
 beforeEach(() => {
+  resetAutosaveState();
   document.body.innerHTML = `
     <input id="promptSearchInput" value="" />
     <div id="promptList"></div>`;
@@ -217,7 +237,7 @@ describe('buildPromptItem — actions', () => {
     expect(saved.MyPrompt).toBeUndefined();
   });
 
-  test('editing the textarea auto-saves after the debounce', () => {
+  test('editing the textarea auto-saves after the debounce', async () => {
     jest.useFakeTimers();
     setupStorage({ MyPrompt: { text: 'old', timestamp: 1 } });
     render();
@@ -225,8 +245,9 @@ describe('buildPromptItem — actions', () => {
     ta.value = 'new body';
     ta.dispatchEvent(new Event('input'));
     jest.advanceTimersByTime(600); // PROMPT_DELAY.AUTOSAVE
+    // The commit is queued on a promise chain, so let the microtasks run.
+    for (let i = 0; i < 4; i++) await Promise.resolve();
     expect(lastSavedPrompts().MyPrompt.text).toBe('new body');
-    jest.useRealTimers();
   });
 
   // --- Losing an edit was the actual bug, so these cover each way it happened ---
@@ -316,4 +337,88 @@ describe('buildPromptItem — actions', () => {
     const lastOpen = global.saveData.mock.calls.at(-1)[0].openPrompts;
     expect(lastOpen).toContain('MyPrompt');
   });
+});
+
+// ---------------------------------------------------------------------------
+// The flush must actually finish before the next action reads storage
+// ---------------------------------------------------------------------------
+
+describe('autosave ordering with asynchronous storage', () => {
+  const settle = async () => { for (let i = 0; i < 12; i++) await new Promise(r => setTimeout(r, 0)); };
+
+  beforeEach(() => { global.window.showCustomModal = jest.fn(); });
+
+  test('an edit is not resurrected by a pin that runs right after the blur', async () => {
+    // Clearing _pendingEdit is synchronous but the write that follows is not.
+    // Pin flushed, saw nothing pending, loaded the OLD text and saved it back
+    // over the edit — reproducible only with async callbacks.
+    const store = setupAsyncStorage({ MyPrompt: { text: 'old', timestamp: 1 } });
+    render();
+    await settle();
+    const ta = firstItem().querySelector('.prompt-text-edit');
+    ta.value = 'edited';
+    ta.dispatchEvent(new Event('input'));
+    ta.dispatchEvent(new Event('blur'));
+    firstItem().querySelector('.pin-btn').click();   // immediately, mid-flight
+    await settle();
+
+    expect(store.prompts.MyPrompt.text).toBe('edited');
+    expect(store.prompts.MyPrompt.pinned).toBe(true);
+  });
+
+  test('an edit is not resurrected by a delete of another prompt', async () => {
+    const store = setupAsyncStorage({
+      MyPrompt: { text: 'old', timestamp: 1 },
+      Other: { text: 'o', timestamp: 2 },
+    });
+    global.window.showCustomModal = jest.fn().mockResolvedValue(true);
+    render();
+    await settle();
+    const ta = itemByTitle('MyPrompt').querySelector('.prompt-text-edit');
+    ta.value = 'edited';
+    ta.dispatchEvent(new Event('input'));
+    ta.dispatchEvent(new Event('blur'));
+    itemByTitle('Other').querySelector('.delete-btn').click();
+    await settle();
+
+    expect(store.prompts.MyPrompt.text).toBe('edited');
+    expect(store.prompts.Other).toBeUndefined();
+  });
+
+  test('two flushes in a row do not race each other', async () => {
+    const store = setupAsyncStorage({ MyPrompt: { text: 'old', timestamp: 1 } });
+    render();
+    await settle();
+    const ta = firstItem().querySelector('.prompt-text-edit');
+    ta.value = 'first';
+    ta.dispatchEvent(new Event('input'));
+    ta.dispatchEvent(new Event('blur'));
+    ta.value = 'second';
+    ta.dispatchEvent(new Event('input'));
+    ta.dispatchEvent(new Event('blur'));
+    await settle();
+
+    expect(store.prompts.MyPrompt.text).toBe('second');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inherited property names must not wedge anything
+// ---------------------------------------------------------------------------
+
+describe('prompt titles that collide with Object.prototype', () => {
+  const settle = async () => { for (let i = 0; i < 8; i++) await new Promise(r => setTimeout(r, 0)); };
+
+  test.each(['toString', 'valueOf', 'hasOwnProperty', 'constructor'])(
+    'a prompt named %s round-trips like any other', async (name) => {
+      // These used to pass the reserved-name check and then behave as if the
+      // prompt already existed, because prompts[name] is inherited and truthy.
+      const store = setupAsyncStorage({ [name]: { text: 'body', timestamp: 1 } });
+      render();
+      await settle();
+      expect(titles()).toContain(name);
+      firstItem().querySelector('.pin-btn').click();
+      await settle();
+      expect(store.prompts[name].pinned).toBe(true);
+    });
 });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -245,3 +245,86 @@ describe('makeMenuAccessible', () => {
     jest.useRealTimers();
   });
 });
+
+describe('makeMenuAccessible — audit follow-ups', () => {
+  function mountMenu(options) {
+    document.body.innerHTML = `
+      <button id="tog"></button>
+      <div id="menu">
+        <div class="dropdown-item" data-value="a"></div>
+        <div class="dropdown-item active" data-value="b"></div>
+        <div class="dropdown-item" data-value="c"></div>
+      </div>`;
+    const tog = $('tog');
+    const menu = $('menu');
+    tog.addEventListener('click', () => menu.classList.toggle('show'));
+    window.makeMenuAccessible(tog, menu, () => menu.querySelectorAll('.dropdown-item'), options);
+    return { tog, menu, items: [...menu.querySelectorAll('.dropdown-item')] };
+  }
+
+  // Enter/Space fire the button's native click, which opens the menu — but focus
+  // stayed on the toggle while every item is tabindex="-1", so the menu was open
+  // with nowhere to go.
+  test('a keyboard-activated click moves focus onto the first option', () => {
+    jest.useFakeTimers();
+    const { tog, menu, items } = mountMenu();
+    tog.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 0 }));
+    jest.advanceTimersByTime(1);
+    expect(menu.classList.contains('show')).toBe(true);
+    expect(document.activeElement).toBe(items[0]);
+    jest.useRealTimers();
+  });
+
+  test('a real mouse click leaves focus where it was', () => {
+    jest.useFakeTimers();
+    const { tog, items } = mountMenu();
+    tog.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
+    jest.advanceTimersByTime(1);
+    expect(document.activeElement).not.toBe(items[0]);
+    jest.useRealTimers();
+  });
+
+  // The bulk-move list stops propagation on its <li> clicks, so the document
+  // listener never saw them and aria-expanded stayed "true" on a closed menu.
+  test('aria-expanded is corrected even when the item click stops propagation', () => {
+    jest.useFakeTimers();
+    const { tog, menu, items } = mountMenu();
+    tog.click();
+    jest.advanceTimersByTime(1);
+    expect(tog.getAttribute('aria-expanded')).toBe('true');
+
+    items[1].addEventListener('click', (e) => {
+      e.stopPropagation();
+      menu.classList.remove('show');
+    });
+    items[1].click();
+    jest.advanceTimersByTime(1);
+
+    expect(menu.classList.contains('show')).toBe(false);
+    expect(tog.getAttribute('aria-expanded')).toBe('false');
+    jest.useRealTimers();
+  });
+
+  test('a single-choice menu exposes which option is selected', () => {
+    const { items } = mountMenu({ radio: true });
+    expect(items.map(i => i.getAttribute('role'))).toEqual(
+      ['menuitemradio', 'menuitemradio', 'menuitemradio']);
+    expect(items.map(i => i.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false']);
+  });
+
+  test('aria-checked follows the selection when it changes', async () => {
+    const { items } = mountMenu({ radio: true });
+    // How the real menus mark a choice: swap the .active class.
+    items[1].classList.remove('active');
+    items[2].classList.add('active');
+    // MutationObserver callbacks are delivered as microtasks.
+    await Promise.resolve();
+    expect(items.map(i => i.getAttribute('aria-checked'))).toEqual(['false', 'false', 'true']);
+  });
+
+  test('a plain menu stays menuitem with no checked state', () => {
+    const { items } = mountMenu();
+    expect(items[0].getAttribute('role')).toBe('menuitem');
+    expect(items[0].hasAttribute('aria-checked')).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up review of #54, #56 and #57. **All six reproduced before fixing**, and each fix has a test verified to fail without it.

## Blocking

### 1. Prompt edits could still be lost (#54)

`flushPendingEdit` cleared `_pendingEdit` **synchronously** and then did an asynchronous load/save. A caller that flushed and immediately read storage read it *before* the write landed:

> blur → click Pin → Pin sees nothing pending, loads the **pre-edit** text, saves it back over the edit.

Commits are now serialized on a promise chain, and the callback runs only after every queued commit has finished writing. Callers with nothing pending still get a **synchronous** callback, so the many "just re-render" call sites are unchanged.

The existing tests could not have caught this — their storage mocks invoke every callback synchronously. Added `setupAsyncStorage` with genuinely async callbacks plus three ordering tests (pin-after-blur, delete-after-blur, two flushes in a row), **verified to fail against the old logic**.

The `pagehide` comment claiming the write is "dispatched synchronously" was wrong and is corrected: it is genuinely best-effort, and `blur` is the path that actually saves.

### 2. The reserved-name check was a blacklist (#54)

A blacklist can never be complete here. `folders[name]` is truthy for **every** member of `Object.prototype`, so `toString`, `valueOf` and `hasOwnProperty` skipped the create-if-missing guard and threw on `.some()` exactly like `__proto__` did:

```
toString         blocked: false | would wedge: true
valueOf          blocked: false | would wedge: true
hasOwnProperty   blocked: false | would wedge: true
```

Existence checks now go through **`hasEntry()`**, an ownership test, across all ten call sites (popup-core, folders, prompts, bulk-actions, utils, both background scripts). Those names become perfectly usable folder titles — strictly better than refusing them.

`isUnsafeKey` is down to the single name an ownership test cannot rescue: `__proto__`, whose *assignment* hits the prototype setter, so the entry is never stored and `JSON.stringify` emits `{}`.

### 3. `build.py` was still fail-open when Jest could not run (#56)

The exception path routed through the old `confirm()`, where `--yes` returned true — so automation could package **without ever running a test**, the exact guarantee #56 set out to establish.

`confirm()` no longer honours `--yes` at all. It means "don't prompt me", not "ship it regardless"; only `--force` continues. Verified by making `subprocess.run` raise:

```
--yes                 -> continue=False | ... -> no. Re-run with --force to build anyway.
--force               -> continue=True  | ... -> yes (--force)
plain non-interactive -> continue=False | ... -> no. Re-run with --force to build anyway.
```

## Accessibility (#57)

- **Enter/Space left focus outside the menu.** Only the arrow keys moved focus; Enter and Space fired the native click, opening the menu while focus stayed on a toggle whose items are all `tabindex="-1"`. Now handled via `e.detail === 0` (keyboard-generated click) — `preventDefault` is not usable here, it would suppress the very click that opens the menu. A real mouse click still leaves focus alone.
- **`aria-expanded` went stale in the bulk-move menu.** Its `<li>` handlers call `stopPropagation`, so the document-level sync never ran and a closed menu kept `aria-expanded="true"`. Re-synced from a **capture** listener on the menu, which fires regardless.
- **The current sort order was visual only.** Both sort menus are now single-choice groups: `menuitemradio` with `aria-checked` tracking the `.active` class through a `MutationObserver`, since that class is applied asynchronously by `loadData` and again on every choice. Plain menus (bulk move) keep `menuitem` and no checked state.

## Test-harness fixes found along the way

- The autosave slot is module-level and outlives a single test, so an edit left pending by one test leaked into the next — added a reset, same test-only export pattern as `prompt-trigger.js`.
- `afterEach` now restores real timers. One fake-timer test threw before its `useRealTimers()`, which silently hung **every later test** that awaited a real timeout — that is what turned a two-line failure into 13 five-second timeouts while I was debugging.

`npx jest` — 644 passing. `python build.py --yes` + `python tools/validate_build.py` — clean.

## Still owed (unchanged)

Manual §5.4 pass on the `#` trigger, the `build` job added to required checks, and a native read of the remaining 40 store locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)