### PR TITLE
test: capture the deliberately simulated quota logs

### DIFF
--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -389,6 +389,13 @@ describe('saveData', () => {
 
   test("reports a local write failure instead of calling back empty", (done) => {
     // callback() with no argument made every caller take its success branch.
+    // The console spies are not decoration: this path is the only place a
+    // service-worker save reports a failure at all (there is no window there, so
+    // the modal fallback never fires), so the log IS the user-visible signal —
+    // and capturing it keeps a deliberately simulated quota error from printing
+    // a scary "QUOTA_BYTES quota exceeded" block in every build.
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     chrome.storage.local.set.mockImplementationOnce((_, cb) => {
       chrome.runtime.lastError = { message: "QUOTA_BYTES quota exceeded" };
       cb();
@@ -398,6 +405,16 @@ describe('saveData', () => {
     saveData({ openFolders: ["Dev"] }, (err) => {
       expect(err).toBeTruthy();
       expect(String(err)).toContain("QUOTA_BYTES");
+      expect(errSpy).toHaveBeenCalledWith(
+        "Local storage write failed:",
+        expect.objectContaining({ message: "QUOTA_BYTES quota exceeded" })
+      );
+      // No window in a service worker, so the warn is the whole report there.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("QUOTA_BYTES quota exceeded")
+      );
+      errSpy.mockRestore();
+      warnSpy.mockRestore();
       done();
     });
   });


### PR DESCRIPTION
`python build.py` printed this on every run, in the middle of an otherwise green build:

```
  ● Console

    console.error
      Local storage write failed: { message: 'QUOTA_BYTES quota exceeded' }
    console.warn
      Storage Error (local): QUOTA_BYTES quota exceeded
```

**Nothing was actually wrong.** It comes from one test I added in #53 — "reports a local write failure instead of calling back empty" — which simulates a full quota on purpose so it can check the error reaches the caller. `saveData` then logs it, correctly, and Jest surfaces the console output.

But an error-shaped block in the output of a passing build is exactly the noise that trains you to skim past it, and the next one might be real. Since the build gate was only just made fail-closed (#56, #58), keeping its output trustworthy matters.

## The fix

The test now spies on `console.error` / `console.warn` and **asserts both**, rather than letting them leak. Output is quiet and the coverage is stronger than before.

That logging is not incidental, which is why asserting it is worth doing: in a service worker there is no `window`, so the modal fallback at `utils.js:264` never fires and the log is the **only** report a failed local write gets.

## Verification

- `npx jest` — 652 passing, **zero `● Console` blocks** (was 1).
- `python build.py --yes` — no `quota`, `error`, `warn` or `console.` line anywhere in the output.
- Still non-vacuous: deleting the `console.error` from `saveData` fails the test.
- `python tools/validate_build.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)