### PR TITLE
feat(folders): add the nesting data layer, inert for now

### DIFF
--- a/src/folders.js
+++ b/src/folders.js
@@ -734,6 +734,13 @@ if (typeof module !== 'undefined') {
   if (typeof sortFolderNames === 'undefined') global.sortFolderNames = _u.sortFolderNames;
   if (typeof sortChats === 'undefined') global.sortChats = _u.sortChats;
   if (typeof EMOJI_PREFIX_REGEX === 'undefined') global.EMOJI_PREFIX_REGEX = _u.EMOJI_PREFIX_REGEX;
+  // Folder-nesting helpers, same reason: globals in the browser, module-scoped here.
+  for (const name of ['getFolderParent', 'getChildFolders', 'getRootFolderNames',
+    'folderSubtreeNames', 'sortedChildFolders', 'sortedRootFolders', 'flattenFolderChats',
+    'canNestFolder', 'withFolderParent', 'pruneFolderParents', 'folderDisplayPath',
+    'folderOpenPath', 'folderSearchState']) {
+    if (typeof global[name] === 'undefined') global[name] = _u[name];
+  }
 
   module.exports = {
     displayFolders,

--- a/src/popup-core.js
+++ b/src/popup-core.js
@@ -387,7 +387,9 @@ function initPopupCommon(config) {
   // --- Export ---
   const exportBtn = document.getElementById('exportBtn');
   exportBtn.addEventListener('click', async () => {
-    loadData({ folders: {}, pinnedFolders: [], prompts: {} }, async (data) => {
+    // folderParents is listed only so a user with no sub-folders still exports a
+    // predictable {} — loadData already copies whatever is in storage.
+    loadData({ folders: {}, pinnedFolders: [], prompts: {}, folderParents: {} }, async (data) => {
       if (Object.keys(data.folders).length === 0 && Object.keys(data.prompts).length === 0) {
         await window.showCustomModal({
           title: chrome.i18n.getMessage("alertEmptyExport") || "Your folders and prompts are empty, nothing to export!",

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,6 +84,270 @@ function sortChats(chats, sortPref) {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Folder nesting — ONE level (root → sub-folder), stored in `folderParents`
+// ---------------------------------------------------------------------------
+//
+// `folderParents` is a plain sync key, sibling of `pinnedFolders`:
+//     { [childFolderName]: parentFolderName }     absent entry = root folder
+//
+// It is deliberately NOT stored on the folder itself: `folders[name]` is a bare
+// array and every consumer relies on Array.isArray() holding, so turning it into
+// an object would mean a data migration — which this codebase has no mechanism
+// for. A missing key simply defaults to {} through loadData, exactly like
+// pinnedFolders, so old installs and old backups need no conversion.
+//
+// Child→parent rather than parent→children: a parent→children map can express
+// "this folder has two parents", a child→parent map cannot.
+//
+// Nesting never touches `pinnedFolders`. A pinned folder dragged into another
+// keeps its pin dormant (the pin button is not rendered on a sub-folder, and
+// children are sorted with no pin list) and gets it back the moment it returns
+// to the top level. That is a requirement, and it holds by doing nothing.
+
+// Does this folder carry a usable parent entry? Non-recursive on purpose: with a
+// corrupt a→b/b→a pair, recursion would never terminate. Here both folders
+// simply read as nested-under-something and getFolderParent sends both back to
+// the root level, which is visible and repairable by the user.
+function hasParentEntry(folders, folderParents, name) {
+  if (!folderParents || !hasEntry(folderParents, name)) return false;
+  const parent = folderParents[name];
+  return typeof parent === 'string' && parent !== name && hasEntry(folders, parent);
+}
+
+// The folder's parent, or null when it is (or must be treated as) a root folder.
+// Returns null for an ORPHAN — a recorded parent that no longer exists — without
+// deleting anything: a read must not write, and the parent may come back from
+// another device on the next sync, which should restore the nesting.
+function getFolderParent(folders, folderParents, name) {
+  if (!hasParentEntry(folders, folderParents, name)) return null;
+  const parent = folderParents[name];
+  // The parent is itself nested: honouring this would be depth 2. Drop the
+  // grandchild to the top level rather than silently rendering a third level.
+  if (hasParentEntry(folders, folderParents, parent)) return null;
+  return parent;
+}
+
+function getChildFolders(folders, folderParents, name) {
+  if (!folders) return [];
+  return Object.keys(folders).filter(n => getFolderParent(folders, folderParents, n) === name);
+}
+
+function getRootFolderNames(folders, folderParents) {
+  if (!folders) return [];
+  return Object.keys(folders).filter(n => getFolderParent(folders, folderParents, n) === null);
+}
+
+// The folder plus its children — what a delete must remove, in one list.
+function folderSubtreeNames(folders, folderParents, name) {
+  return [name, ...getChildFolders(folders, folderParents, name)];
+}
+
+// A shallow { name: chats } view of a subset, so the existing sortFolderNames can
+// order a subset without being modified (and without its callers changing).
+function pickFolders(folders, names) {
+  const subset = {};
+  for (const n of names) if (hasEntry(folders, n)) subset[n] = folders[n];
+  return subset;
+}
+
+// Children in display order. The pin list is deliberately NOT passed: a dormant
+// pin on a nested folder must not reorder its siblings.
+function sortedChildFolders(folders, folderParents, name, sortPref) {
+  return sortFolderNames(pickFolders(folders, getChildFolders(folders, folderParents, name)), [], sortPref);
+}
+
+// Every conversation under a folder: its own first, then each child's, each set
+// sorted by the current preference. Used by the tab-group button and by the root
+// sort below.
+function flattenFolderChats(folders, folderParents, name, sortPref) {
+  const own = Array.isArray(folders[name]) ? sortChats(folders[name], sortPref) : [];
+  const out = [...own];
+  for (const child of sortedChildFolders(folders, folderParents, name, sortPref)) {
+    if (Array.isArray(folders[child])) out.push(...sortChats(folders[child], sortPref));
+  }
+  return out;
+}
+
+// Root folders in display order. Each root is ranked on its WHOLE subtree, so a
+// parent whose only recent activity happened inside a sub-folder still sorts as
+// recent under dateDesc instead of sinking to the bottom.
+function sortedRootFolders(folders, folderParents, pinnedFolders, sortPref) {
+  const view = {};
+  for (const name of getRootFolderNames(folders, folderParents)) {
+    view[name] = flattenFolderChats(folders, folderParents, name, sortPref);
+  }
+  return sortFolderNames(view, pinnedFolders, sortPref);
+}
+
+// May `child` be dropped into `parent`? Returns { ok: true } or a reason the
+// caller turns into a message: 'missing' | 'self' | 'depth' | 'already'.
+function canNestFolder(folders, folderParents, child, parent) {
+  if (typeof child !== 'string' || typeof parent !== 'string') return { ok: false, reason: 'missing' };
+  if (child === parent) return { ok: false, reason: 'self' };
+  if (isUnsafeKey(child) || isUnsafeKey(parent)) return { ok: false, reason: 'missing' };
+  if (!hasEntry(folders, child) || !hasEntry(folders, parent)) return { ok: false, reason: 'missing' };
+  // Only one level: the target must be a root folder, and the dragged folder
+  // must not already be a parent itself.
+  if (getFolderParent(folders, folderParents, parent) !== null) return { ok: false, reason: 'depth' };
+  if (getChildFolders(folders, folderParents, child).length > 0) return { ok: false, reason: 'depth' };
+  if (getFolderParent(folders, folderParents, child) === parent) return { ok: false, reason: 'already' };
+  return { ok: true };
+}
+
+// New map with `child` nested under `parent`, or moved back to the top level
+// when parent is null. Pure — the caller decides when to persist.
+function withFolderParent(folderParents, child, parent) {
+  const next = { ...(folderParents || {}) };
+  if (typeof child !== 'string' || isUnsafeKey(child)) return next;
+  if (parent === null || parent === undefined) delete next[child];
+  else next[child] = parent;
+  return next;
+}
+
+// Self-healing copy: drops orphans, self-references and depth-2 entries. Run it
+// before every save that carries folderParents, so a parent deleted on another
+// device cannot leave the map growing forever.
+function pruneFolderParents(folders, folderParents) {
+  const next = {};
+  for (const child of Object.keys(folderParents || {})) {
+    if (!hasEntry(folders, child)) continue;
+    const parent = getFolderParent(folders, folderParents, child);
+    if (parent !== null) next[child] = parent;
+  }
+  return next;
+}
+
+// "Parent/Child" for the folder-name box, or just the name at the top level.
+// Raw names on both sides (emoji prefixes included) so the value round-trips
+// through resolveFolderPath — the input already carries the raw name today.
+function folderDisplayPath(folders, folderParents, name) {
+  const parent = getFolderParent(folders, folderParents, name);
+  return parent ? `${parent}/${name}` : name;
+}
+
+// Which folders must be expanded for `name` to be visible after a re-render.
+function folderOpenPath(folders, folderParents, name) {
+  const parent = getFolderParent(folders, folderParents, name);
+  return parent ? [parent, name] : [name];
+}
+
+// What the folder-name box means. Returns
+//   { name, parent, created: string[], error: null | 'nestTooDeep' | 'exists' }
+// with name === null when the caller should fall back to its own default.
+//
+// Rule 1 is load-bearing: an existing folder literally named "a/b" must keep
+// working, so an exact match always beats the path interpretation. Every cut
+// point is tried, not just the first, so a name containing a slash on either
+// side still resolves.
+function resolveFolderPath(folders, folderParents, typed) {
+  const value = (typed || '').trim();
+  const empty = { name: null, parent: null, created: [], error: null };
+  if (!value) return empty;
+
+  if (hasEntry(folders, value)) {
+    return { name: value, parent: getFolderParent(folders, folderParents, value), created: [], error: null };
+  }
+
+  const cuts = [];
+  for (let i = value.indexOf('/'); i !== -1; i = value.indexOf('/', i + 1)) {
+    const left = value.slice(0, i).trim();
+    const right = value.slice(i + 1).trim();
+    if (!left || !right || isUnsafeKey(left) || isUnsafeKey(right)) continue;
+    cuts.push({ left, right });
+  }
+
+  // An existing pair wins over creating anything.
+  for (const { left, right } of cuts) {
+    if (hasEntry(folders, left) && hasEntry(folders, right)
+        && getFolderParent(folders, folderParents, right) === left) {
+      return { name: right, parent: left, created: [], error: null };
+    }
+  }
+
+  if (cuts.length > 0) {
+    const { left, right } = cuts[0];
+    if (getFolderParent(folders, folderParents, left) !== null) {
+      return { name: null, parent: null, created: [], error: 'nestTooDeep' };
+    }
+    // The child name is taken somewhere else — refuse rather than silently
+    // re-parenting a folder the user did not drag.
+    if (hasEntry(folders, right)) {
+      return { name: null, parent: null, created: [], error: 'exists' };
+    }
+    const created = [];
+    if (!hasEntry(folders, left)) created.push(left);
+    created.push(right);
+    return { name: right, parent: left, created, error: null };
+  }
+
+  return { name: value, parent: null, created: hasEntry(folders, value) ? [] : [value], error: null };
+}
+
+// What a search term makes visible for one folder — computed without the DOM so
+// it can be unit-tested. `show` false means the folder is filtered out entirely;
+// `showAllChats` means the folder itself matched, so all of its conversations
+// stay visible (the pre-existing behaviour for a name match).
+//
+// A root must also surface when only a CHILD matches: the parent is filtered
+// first, so without that clause a matching sub-folder would be unreachable.
+function folderSearchState(folders, folderParents, name, term) {
+  const needle = (term || '').toLowerCase();
+  if (!needle) return { show: true, showAllChats: true };
+
+  const nameMatches = (n) => n.toLowerCase().includes(needle);
+  const chatMatches = (n) => Array.isArray(folders[n])
+    && folders[n].some(c => (c.title || '').toLowerCase().includes(needle));
+
+  const parent = getFolderParent(folders, folderParents, name);
+  const self = nameMatches(name);
+
+  if (parent) {
+    const viaParent = nameMatches(parent);
+    return { show: viaParent || self || chatMatches(name), showAllChats: viaParent || self };
+  }
+
+  const viaChild = getChildFolders(folders, folderParents, name)
+    .some(child => nameMatches(child) || chatMatches(child));
+  return { show: self || chatMatches(name) || viaChild, showAllChats: self };
+}
+
+// The two-level context menu, as data. Both background.js build their menu from
+// this so the two copies (deliberately unshared, CLAUDE.md §6) cannot drift, and
+// so the shape is unit-testable — there is no test suite for background.js.
+//
+// A contextMenus item that has children is not clickable itself, hence the
+// explicit "save here" entry under a parent. Ids stay `folder_<name>` at BOTH
+// levels: folder names are unique keys of one flat object, so the id already
+// identifies the target unambiguously and survives a service-worker restart.
+// Only the submenu containers take a `sub_` prefix, which the click handler
+// never accepts as a save target.
+function buildContextMenuModel(folders, folderParents, opts = {}) {
+  const rootId = opts.rootId;
+  const saveHereTitle = opts.saveHereTitle || '';
+  const label = (name) => {
+    const match = name.match(EMOJI_PREFIX_REGEX);
+    return match ? `${match[1]} ${name.replace(EMOJI_PREFIX_REGEX, '')}` : `📁 ${name}`;
+  };
+
+  const items = [];
+  for (const root of getRootFolderNames(folders, folderParents).sort()) {
+    const children = getChildFolders(folders, folderParents, root).sort();
+    if (children.length === 0) {
+      items.push({ id: `folder_${root}`, parentId: rootId, title: label(root) });
+      continue;
+    }
+    const subId = `sub_${root}`;
+    items.push({ id: subId, parentId: rootId, title: label(root) });
+    items.push({ id: `folder_${root}`, parentId: subId, title: saveHereTitle });
+    items.push({ id: `sep_${root}`, parentId: subId, type: 'separator' });
+    for (const child of children) {
+      items.push({ id: `folder_${child}`, parentId: subId, title: label(child) });
+    }
+  }
+  return items;
+}
+
 function loadData(defaults, callback) {
   chrome.storage.sync.get(null, (syncResult) => {
     chrome.storage.local.get(null, (localResult) => {
@@ -185,7 +449,12 @@ function saveData(dataToSave, callback) {
     // folders or open/closed prompts. NOTE: this is deliberately broader than
     // isContentSave — pinning a folder or changing the sort order must still
     // re-sync the bookmark order even though no conversation/prompt changed.
-    const affectsBookmarks = !!(dataToSave.folders || dataToSave.pinnedFolders || dataToSave.sortPref);
+    // folderParents belongs here for the same reason: nesting a folder rewrites
+    // the shape of the mirrored tree while writing no `folders` at all, so
+    // without it the bookmark tree would keep showing the old layout until the
+    // next conversation was saved.
+    const affectsBookmarks = !!(dataToSave.folders || dataToSave.pinnedFolders
+      || dataToSave.sortPref || dataToSave.folderParents);
 
     // --- Folders → sync, split into chunks to stay under kQuotaBytesPerItem (8 192 B) ---
     if (dataToSave.folders) {
@@ -300,10 +569,11 @@ function saveDataAsync(dataToSave) {
 // Callers that don't pass the extra params continue to work unchanged.
 function finishSave(callback, err = null, countSave = true, affectsBookmarks = true) {
   if (affectsBookmarks) {
-    chrome.storage.sync.get(['syncBookmarksEnabled', 'pinnedFolders', 'sortPref'], (syncData) => {
+    chrome.storage.sync.get(['syncBookmarksEnabled', 'pinnedFolders', 'sortPref', 'folderParents'], (syncData) => {
       if (syncData.syncBookmarksEnabled) {
         loadData({ folders: {} }, (data) => {
-          syncToBookmarksTree(data.folders, syncData.pinnedFolders || [], syncData.sortPref || 'dateDesc');
+          syncToBookmarksTree(data.folders, syncData.pinnedFolders || [], syncData.sortPref || 'dateDesc',
+            syncData.folderParents || {});
         });
       }
     });
@@ -323,7 +593,7 @@ function finishSave(callback, err = null, countSave = true, affectsBookmarks = t
 // --- BOOKMARKS SYNCHRONIZATION (MOBILE) ---
 let isSyncingToBookmarks = false;
 
-async function syncToBookmarksTree(folders, pinnedFolders = [], sortPref = 'dateDesc') {
+async function syncToBookmarksTree(folders, pinnedFolders = [], sortPref = 'dateDesc', folderParents = {}) {
   // 1. Stop if a sync is ongoing
   if (isSyncingToBookmarks) {
     return;
@@ -350,25 +620,27 @@ async function syncToBookmarksTree(folders, pinnedFolders = [], sortPref = 'date
     // 4. Master folder creation
     const masterNode = await new Promise(r => chrome.bookmarks.create({ title: MASTER_FOLDER_NAME }, r));
 
-    // 5. Folder and bookmark creation loop (sorted)
-    const finalOrder = sortFolderNames(folders, pinnedFolders, sortPref);
-    for (let i = 0; i < finalOrder.length; i++) {
-      const folderName = finalOrder[i];
+    // 5. Folder and bookmark creation loop (sorted).
+    //
+    // The mirror is nested exactly like the popup: a sub-folder becomes a real
+    // bookmark folder inside its parent, after the parent's own conversations.
+    // Flattening it to "Parent / Child" at the top level would both lose the
+    // layout the feature exists to give and collide on names.
+    const createFolderNode = async (parentId, folderName, index) => {
       const match = folderName.match(EMOJI_PREFIX_REGEX);
       const displayFolderName = match
         ? `${match[1]} ${folderName.slice(match[0].length)}`
         : folderName;
 
       const folderNode = await new Promise(r => chrome.bookmarks.create({
-        parentId: masterNode.id,
+        parentId,
         title: displayFolderName,
-        index: i
+        index
       }, r));
 
-      const chats = sortChats(folders[folderName], sortPref);
-
-      for (let j = 0; j < chats.length; j++) {
-        const chat = chats[j];
+      const chats = sortChats(folders[folderName] || [], sortPref);
+      let childIndex = 0;
+      for (const chat of chats) {
         // Defence-in-depth: never mirror an unsafe URL into the bookmark tree,
         // even if legacy/corrupt storage carries one (import already gates on this).
         if (!isSafeUrl(chat.url)) continue;
@@ -376,8 +648,22 @@ async function syncToBookmarksTree(folders, pinnedFolders = [], sortPref = 'date
           parentId: folderNode.id,
           title: chat.title,
           url: chat.url,
-          index: j
+          index: childIndex++
         }, r));
+      }
+      return { folderNode, nextIndex: childIndex };
+    };
+
+    const finalOrder = sortedRootFolders(folders, folderParents, pinnedFolders, sortPref);
+    for (let i = 0; i < finalOrder.length; i++) {
+      const folderName = finalOrder[i];
+      const { folderNode, nextIndex } = await createFolderNode(masterNode.id, folderName, i);
+
+      // Sub-folders continue the parent's index sequence, so they land after its
+      // conversations rather than being interleaved with them.
+      let subIndex = nextIndex;
+      for (const child of sortedChildFolders(folders, folderParents, folderName, sortPref)) {
+        await createFolderNode(folderNode.id, child, subIndex++);
       }
     }
   } catch (error) {
@@ -459,10 +745,11 @@ function mergeImportData(importedData) {
       return reject(new Error("Invalid Format"));
     }
 
-    loadData({ folders: {}, pinnedFolders: [], prompts: {} }, (data) => {
+    loadData({ folders: {}, pinnedFolders: [], prompts: {}, folderParents: {} }, (data) => {
       let currentFolders = data.folders || {};
       let currentPinned = data.pinnedFolders || [];
       let currentPrompts = data.prompts || {};
+      let currentParents = data.folderParents || {};
 
       const isPlainObject = (v) => v && typeof v === 'object' && !Array.isArray(v);
 
@@ -472,6 +759,7 @@ function mergeImportData(importedData) {
       let foldersToImport = {};
       let pinsToImport = [];
       let promptsToImport = {};
+      let parentsToImport = {};
 
       if (isPlainObject(importedData.folders)) {
         foldersToImport = importedData.folders;
@@ -480,6 +768,11 @@ function mergeImportData(importedData) {
         }
         if (isPlainObject(importedData.prompts)) {
           promptsToImport = importedData.prompts;
+        }
+        // Backups written before nesting existed simply carry no map: everything
+        // they contain imports at the top level, which is what it was.
+        if (isPlainObject(importedData.folderParents)) {
+          parentsToImport = importedData.folderParents;
         }
       } else if (!('folders' in importedData) && !('prompts' in importedData)) {
         // Legacy flat format: the object itself maps folder names to chat arrays.
@@ -531,11 +824,27 @@ function mergeImportData(importedData) {
         }
       }
 
+      // 4. Merge the nesting, AFTER the folders so both ends can be checked
+      //    against the merged result. An entry is taken only when it is safe on
+      //    its own terms; a folder that already has a local placement keeps it,
+      //    the same "existing entry wins" policy the prompt merge uses.
+      for (const [child, parent] of Object.entries(parentsToImport)) {
+        if (typeof child !== 'string' || typeof parent !== 'string') continue;
+        if (hasEntry(currentParents, child)) continue;
+        if (!canNestFolder(currentFolders, currentParents, child, parent).ok) continue;
+        currentParents[child] = parent;
+      }
+
       // Final save. Reject on a storage failure instead of resolving blindly:
       // an import that hit the quota was reporting "Import successful!" while
       // nothing had been written — the worst possible moment to be wrong, since
       // the user is likely restoring a backup after losing data.
-      saveData({ folders: currentFolders, pinnedFolders: currentPinned, prompts: currentPrompts }, (err) => {
+      saveData({
+        folders: currentFolders,
+        pinnedFolders: currentPinned,
+        prompts: currentPrompts,
+        folderParents: pruneFolderParents(currentFolders, currentParents),
+      }, (err) => {
         if (err) reject(new Error(err));
         else resolve();
       });
@@ -926,6 +1235,22 @@ if (typeof module !== 'undefined') {
     makeChunks,
     sortFolderNames,
     sortChats,
+    getFolderParent,
+    getChildFolders,
+    getRootFolderNames,
+    folderSubtreeNames,
+    pickFolders,
+    sortedChildFolders,
+    sortedRootFolders,
+    flattenFolderChats,
+    canNestFolder,
+    withFolderParent,
+    pruneFolderParents,
+    folderDisplayPath,
+    folderOpenPath,
+    resolveFolderPath,
+    folderSearchState,
+    buildContextMenuModel,
     loadData,
     saveData,
     finishSave,

--- a/tests/folder-nesting.test.js
+++ b/tests/folder-nesting.test.js
@@ -1,0 +1,297 @@
+// Folder nesting is stored in a side map (`folderParents`), so the invariants —
+// one level, no orphans, no cycles — live entirely in these pure helpers rather
+// than in the renderer. This suite is where they are pinned down; the DOM tests
+// only check that displayFolders asks the right questions.
+
+const {
+  getFolderParent,
+  getChildFolders,
+  getRootFolderNames,
+  folderSubtreeNames,
+  sortedChildFolders,
+  sortedRootFolders,
+  flattenFolderChats,
+  canNestFolder,
+  withFolderParent,
+  pruneFolderParents,
+  folderDisplayPath,
+  folderOpenPath,
+  resolveFolderPath,
+  folderSearchState,
+  buildContextMenuModel,
+} = require('../src/utils');
+
+const chat = (title, timestamp) => ({ title, url: `https://a/${title}`, timestamp });
+
+// Work ─ Clients          Personal (root, no children)
+const TREE = {
+  folders: {
+    Work: [chat('w1', 10)],
+    Clients: [chat('c1', 30)],
+    Personal: [chat('p1', 20)],
+  },
+  parents: { Clients: 'Work' },
+};
+
+describe('getFolderParent', () => {
+  test('returns the parent of a nested folder and null for a root one', () => {
+    expect(getFolderParent(TREE.folders, TREE.parents, 'Clients')).toBe('Work');
+    expect(getFolderParent(TREE.folders, TREE.parents, 'Work')).toBeNull();
+    expect(getFolderParent(TREE.folders, TREE.parents, 'Personal')).toBeNull();
+  });
+
+  test('an orphan (parent deleted elsewhere) reads as a root folder', () => {
+    expect(getFolderParent({ Clients: [] }, { Clients: 'Work' }, 'Clients')).toBeNull();
+  });
+
+  test('a grandchild is refused rather than rendered at a third level', () => {
+    const folders = { A: [], B: [], C: [] };
+    // C → B → A would be depth 2.
+    expect(getFolderParent(folders, { B: 'A', C: 'B' }, 'C')).toBeNull();
+    expect(getFolderParent(folders, { B: 'A', C: 'B' }, 'B')).toBe('A');
+  });
+
+  test('a two-folder cycle sends both back to the top level instead of looping', () => {
+    const folders = { A: [], B: [] };
+    expect(getFolderParent(folders, { A: 'B', B: 'A' }, 'A')).toBeNull();
+    expect(getFolderParent(folders, { A: 'B', B: 'A' }, 'B')).toBeNull();
+  });
+
+  test('a folder that is its own parent reads as a root folder', () => {
+    expect(getFolderParent({ A: [] }, { A: 'A' }, 'A')).toBeNull();
+  });
+
+  test('an inherited name is not a parent entry (hasEntry, not truthiness)', () => {
+    expect(getFolderParent({ toString: [] }, {}, 'toString')).toBeNull();
+  });
+});
+
+describe('children and roots', () => {
+  test('splits the flat namespace into roots and children', () => {
+    expect(getRootFolderNames(TREE.folders, TREE.parents).sort()).toEqual(['Personal', 'Work']);
+    expect(getChildFolders(TREE.folders, TREE.parents, 'Work')).toEqual(['Clients']);
+    expect(getChildFolders(TREE.folders, TREE.parents, 'Personal')).toEqual([]);
+  });
+
+  test('folderSubtreeNames lists what a delete has to remove', () => {
+    expect(folderSubtreeNames(TREE.folders, TREE.parents, 'Work')).toEqual(['Work', 'Clients']);
+    expect(folderSubtreeNames(TREE.folders, TREE.parents, 'Clients')).toEqual(['Clients']);
+  });
+});
+
+describe('ordering', () => {
+  test('a root is ranked on its whole subtree, not just its own conversations', () => {
+    // Work's own chat is older than Personal's, but its sub-folder holds the
+    // newest conversation of all — so Work must come first under dateDesc.
+    expect(sortedRootFolders(TREE.folders, TREE.parents, [], 'dateDesc')).toEqual(['Work', 'Personal']);
+    // Children never appear in the root list.
+    expect(sortedRootFolders(TREE.folders, TREE.parents, [], 'dateDesc')).not.toContain('Clients');
+  });
+
+  test('a pinned root still wins over an active one', () => {
+    expect(sortedRootFolders(TREE.folders, TREE.parents, ['Personal'], 'dateDesc'))
+      .toEqual(['Personal', 'Work']);
+  });
+
+  test('a dormant pin does not reorder sub-folders', () => {
+    const folders = { Work: [], Alpha: [chat('a', 1)], Beta: [chat('b', 2)] };
+    const parents = { Alpha: 'Work', Beta: 'Work' };
+    // Beta is pinned, but pins are ignored inside a parent: dateDesc order stands.
+    expect(sortedChildFolders(folders, parents, 'Work', 'dateDesc')).toEqual(['Beta', 'Alpha']);
+    expect(sortedChildFolders(folders, parents, 'Work', 'alphaAsc')).toEqual(['Alpha', 'Beta']);
+  });
+
+  test('flattenFolderChats returns own conversations first, then each child\'s', () => {
+    const folders = {
+      Work: [chat('w1', 1), chat('w2', 5)],
+      Clients: [chat('c1', 9)],
+      Research: [chat('r1', 7)],
+    };
+    const parents = { Clients: 'Work', Research: 'Work' };
+    expect(flattenFolderChats(folders, parents, 'Work', 'dateDesc').map(c => c.title))
+      .toEqual(['w2', 'w1', 'c1', 'r1']);
+    // A child only ever contributes its own conversations.
+    expect(flattenFolderChats(folders, parents, 'Clients', 'dateDesc').map(c => c.title)).toEqual(['c1']);
+  });
+});
+
+describe('canNestFolder', () => {
+  const folders = { Work: [], Clients: [], Personal: [], Parent: [], Kid: [] };
+  const parents = { Clients: 'Work', Kid: 'Parent' };
+
+  test('accepts a root folder dropped on another root folder', () => {
+    expect(canNestFolder(folders, parents, 'Personal', 'Work')).toEqual({ ok: true });
+  });
+
+  test.each([
+    ['itself', 'Work', 'Work', 'self'],
+    ['a sub-folder as the target', 'Personal', 'Clients', 'depth'],
+    ['a folder that already has children', 'Parent', 'Work', 'depth'],
+    ['its current parent', 'Clients', 'Work', 'already'],
+    ['a folder that does not exist', 'Ghost', 'Work', 'missing'],
+    ['a reserved name', '__proto__', 'Work', 'missing'],
+  ])('refuses %s', (_label, child, parent, reason) => {
+    expect(canNestFolder(folders, parents, child, parent)).toEqual({ ok: false, reason });
+  });
+});
+
+describe('withFolderParent / pruneFolderParents', () => {
+  test('nests and un-nests without mutating the original map', () => {
+    const before = { Clients: 'Work' };
+    expect(withFolderParent(before, 'Personal', 'Work')).toEqual({ Clients: 'Work', Personal: 'Work' });
+    expect(withFolderParent(before, 'Clients', null)).toEqual({});
+    expect(before).toEqual({ Clients: 'Work' });
+  });
+
+  test('drops orphans, self-references, depth-2 entries and vanished children', () => {
+    const folders = { A: [], B: [], C: [], Solo: [] };
+    const pruned = pruneFolderParents(folders, {
+      B: 'A',          // valid
+      C: 'B',          // depth 2
+      Solo: 'Gone',    // orphan: parent no longer exists
+      A: 'A',          // self-reference
+      Deleted: 'A',    // the child itself is gone
+    });
+    expect(pruned).toEqual({ B: 'A' });
+  });
+});
+
+describe('display path', () => {
+  test('shows Parent/Child for a sub-folder and the bare name at the top level', () => {
+    expect(folderDisplayPath(TREE.folders, TREE.parents, 'Clients')).toBe('Work/Clients');
+    expect(folderDisplayPath(TREE.folders, TREE.parents, 'Work')).toBe('Work');
+  });
+
+  test('folderOpenPath expands the parent too, so a child is not saved out of sight', () => {
+    expect(folderOpenPath(TREE.folders, TREE.parents, 'Clients')).toEqual(['Work', 'Clients']);
+    expect(folderOpenPath(TREE.folders, TREE.parents, 'Work')).toEqual(['Work']);
+  });
+
+  test('a display path round-trips through resolveFolderPath', () => {
+    const path = folderDisplayPath(TREE.folders, TREE.parents, 'Clients');
+    expect(resolveFolderPath(TREE.folders, TREE.parents, path))
+      .toEqual({ name: 'Clients', parent: 'Work', created: [], error: null });
+  });
+});
+
+describe('resolveFolderPath', () => {
+  test('an existing folder wins over the path reading, slash or not', () => {
+    // The one that matters: a folder literally named "a/b" predates nesting.
+    const folders = { 'a/b': [], a: [], b: [] };
+    expect(resolveFolderPath(folders, {}, 'a/b'))
+      .toEqual({ name: 'a/b', parent: null, created: [], error: null });
+  });
+
+  test('a plain name targets a top-level folder', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, 'Work'))
+      .toEqual({ name: 'Work', parent: null, created: [], error: null });
+  });
+
+  test('a new plain name is created at the top level', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, 'Ideas'))
+      .toEqual({ name: 'Ideas', parent: null, created: ['Ideas'], error: null });
+  });
+
+  test('an unknown pair creates both halves, nested', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, 'Studies/Math'))
+      .toEqual({ name: 'Math', parent: 'Studies', created: ['Studies', 'Math'], error: null });
+  });
+
+  test('an existing parent only creates the child', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, 'Work/Invoices'))
+      .toEqual({ name: 'Invoices', parent: 'Work', created: ['Invoices'], error: null });
+  });
+
+  test('refuses to nest under a folder that is itself nested', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, 'Clients/Deep').error).toBe('nestTooDeep');
+  });
+
+  test('refuses to silently re-parent a folder that already exists elsewhere', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, 'Personal/Clients').error).toBe('exists');
+  });
+
+  test('whitespace around the slash is trimmed', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, ' Work / Invoices ').parent).toBe('Work');
+  });
+
+  test('an empty value asks the caller for its own default', () => {
+    expect(resolveFolderPath(TREE.folders, TREE.parents, '   ').name).toBeNull();
+  });
+
+  test('a reserved segment falls back to a plain folder name', () => {
+    const result = resolveFolderPath(TREE.folders, TREE.parents, '__proto__/x');
+    expect(result.parent).toBeNull();
+    expect(result.name).toBe('__proto__/x');
+  });
+});
+
+describe('folderSearchState', () => {
+  const folders = {
+    Work: [chat('quarterly report', 1)],
+    Clients: [chat('acme onboarding', 2)],
+    Personal: [chat('recipes', 3)],
+  };
+  const parents = { Clients: 'Work' };
+  const state = (name, term) => folderSearchState(folders, parents, name, term);
+
+  test('no search term shows everything', () => {
+    expect(state('Personal', '')).toEqual({ show: true, showAllChats: true });
+  });
+
+  test('a root surfaces when only its sub-folder name matches', () => {
+    expect(state('Work', 'client').show).toBe(true);
+    expect(state('Work', 'client').showAllChats).toBe(false);
+    expect(state('Clients', 'client')).toEqual({ show: true, showAllChats: true });
+    expect(state('Personal', 'client').show).toBe(false);
+  });
+
+  test('a root surfaces when only a conversation inside its sub-folder matches', () => {
+    expect(state('Work', 'acme').show).toBe(true);
+    expect(state('Clients', 'acme')).toEqual({ show: true, showAllChats: false });
+  });
+
+  test('a matching parent name reveals its whole sub-folder', () => {
+    expect(state('Work', 'work')).toEqual({ show: true, showAllChats: true });
+    expect(state('Clients', 'work')).toEqual({ show: true, showAllChats: true });
+  });
+
+  test('a folder with nothing matching is filtered out', () => {
+    expect(state('Work', 'zzz').show).toBe(false);
+    expect(state('Clients', 'zzz').show).toBe(false);
+  });
+});
+
+describe('buildContextMenuModel', () => {
+  const model = () => buildContextMenuModel(TREE.folders, TREE.parents,
+    { rootId: 'root', saveHereTitle: 'ctxMenuSave' });
+
+  test('a childless root is a single clickable item', () => {
+    expect(model()).toContainEqual({ id: 'folder_Personal', parentId: 'root', title: '📁 Personal' });
+  });
+
+  test('a root with children becomes a submenu that stays selectable itself', () => {
+    expect(model()).toEqual([
+      { id: 'folder_Personal', parentId: 'root', title: '📁 Personal' },
+      { id: 'sub_Work', parentId: 'root', title: '📁 Work' },
+      { id: 'folder_Work', parentId: 'sub_Work', title: 'ctxMenuSave' },
+      { id: 'sep_Work', parentId: 'sub_Work', type: 'separator' },
+      { id: 'folder_Clients', parentId: 'sub_Work', title: '📁 Clients' },
+    ]);
+  });
+
+  test('every save target is a folder_ id — a submenu container is never one', () => {
+    for (const item of model()) {
+      if (item.type === 'separator') continue;
+      const isTarget = item.id.startsWith('folder_');
+      expect(isTarget || item.id.startsWith('sub_')).toBe(true);
+      // The name is recoverable from the id alone, which is what survives a
+      // service-worker restart.
+      if (isTarget) expect(TREE.folders[item.id.slice('folder_'.length)]).toBeDefined();
+    }
+  });
+
+  test('a custom emoji prefix is kept as the menu icon', () => {
+    const items = buildContextMenuModel({ '🚀 Launch': [] }, {}, { rootId: 'root' });
+    expect(items[0].title).toBe('🚀 Launch');
+  });
+});

--- a/tests/folders.test.js
+++ b/tests/folders.test.js
@@ -15,12 +15,13 @@ function makeFolder(...chats) {
   }));
 }
 
-function setupStorage(folders, pinnedFolders = [], openFolders = []) {
+function setupStorage(folders, pinnedFolders = [], openFolders = [], folderParents = {}) {
   global.loadData = jest.fn((defaults, cb) =>
     cb({
       folders: JSON.parse(JSON.stringify(folders)),
       pinnedFolders: [...pinnedFolders],
       openFolders: [...openFolders],
+      folderParents: { ...folderParents },
     })
   );
   global.saveData = jest.fn((data, cb) => cb && cb());

--- a/tests/utils-helpers.test.js
+++ b/tests/utils-helpers.test.js
@@ -219,6 +219,42 @@ describe('syncToBookmarksTree', () => {
     expect(chatCreates.map((o) => o.url)).toEqual(['https://a/ok']);
   });
 
+  test('mirrors a sub-folder INSIDE its parent, after the parent conversations', async () => {
+    const folders = {
+      Work: [{ title: 'w1', url: 'https://a/w1', timestamp: 5 }],
+      Clients: [{ title: 'c1', url: 'https://a/c1', timestamp: 9 }],
+    };
+
+    await syncToBookmarksTree(folders, [], 'dateDesc', { Clients: 'Work' });
+
+    // Clients is a child, so it never appears at the top level…
+    expect(order).toEqual([
+      'remove:stale',
+      'create:folder(masterFolderName)',
+      'create:folder(Work)',
+      'create:chat(w1)',
+      'create:folder(Clients)',
+      'create:chat(c1)',
+    ]);
+
+    // …it hangs off Work, at the index right after Work's own conversation.
+    // The mock hands out ids in creation order: master=node0, Work=node1.
+    const creates = chrome.bookmarks.create.mock.calls.map((c) => c[0]);
+    const work = creates.find((o) => o.title === 'Work');
+    const clients = creates.find((o) => o.title === 'Clients');
+    expect(work.parentId).toBe('node0');
+    expect(clients.parentId).toBe('node1');
+    expect(clients.index).toBe(1);
+  });
+
+  test('an orphaned nesting entry mirrors at the top level rather than vanishing', async () => {
+    const folders = { Solo: [{ title: 's', url: 'https://a/s', timestamp: 1 }] };
+
+    await syncToBookmarksTree(folders, [], 'dateDesc', { Solo: 'DeletedParent' });
+
+    expect(order).toContain('create:folder(Solo)');
+  });
+
   test('a re-entrant call while a sync is in flight is ignored', async () => {
     const folders = { A: [{ title: 'c', url: 'https://a/y', timestamp: 1 }] };
     const first = syncToBookmarksTree(folders, [], 'dateDesc'); // holds the lock

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -575,6 +575,62 @@ describe('mergeImportData', () => {
     expect(savedFolders().Dev).toHaveLength(1);
   });
 
+  // The nesting map is merged after the folders, so both ends can be checked
+  // against the merged result. A backup must never be able to create a second
+  // level, a cycle, or a pointer to a folder that isn't there.
+  function savedParents() {
+    const calls = chrome.storage.sync.set.mock.calls;
+    const arg = calls.map((c) => c[0]).reverse().find((a) => a && a.folderParents);
+    return arg ? arg.folderParents : null;
+  }
+
+  test('imports the folder nesting from a backup', async () => {
+    const chat = (u) => [{ title: 'c', url: `https://gemini.google.com/app/${u}`, timestamp: 1 }];
+    await mergeImportData({
+      folders: { Work: chat('a'), Clients: chat('b') },
+      folderParents: { Clients: 'Work' },
+    });
+    expect(savedParents()).toEqual({ Clients: 'Work' });
+  });
+
+  test('drops nesting entries that point at a folder the backup does not carry', async () => {
+    const chat = (u) => [{ title: 'c', url: `https://gemini.google.com/app/${u}`, timestamp: 1 }];
+    await mergeImportData({
+      folders: { Clients: chat('b') },
+      folderParents: { Clients: 'Ghost' },
+    });
+    expect(savedParents()).toEqual({});
+  });
+
+  test('refuses a backup that would create a second level or a cycle', async () => {
+    const chat = (u) => [{ title: 'c', url: `https://gemini.google.com/app/${u}`, timestamp: 1 }];
+    await mergeImportData({
+      folders: { A: chat('a'), B: chat('b'), C: chat('c'), D: chat('d') },
+      folderParents: { B: 'A', C: 'B', D: 'D' },
+    });
+    expect(savedParents()).toEqual({ B: 'A' });
+  });
+
+  test('a local placement wins over the backup', async () => {
+    const existing = { Work: [], Personal: [], Clients: [] };
+    chrome.storage.sync.get
+      .mockImplementationOnce((_, cb) => cb({
+        foldersDataCompressed: `C:${JSON.stringify(existing)}`,
+        folderParents: { Clients: 'Personal' },
+      }))
+      .mockImplementation((_, cb) => cb({ syncPromptsEnabled: false, syncBookmarksEnabled: false }));
+
+    await mergeImportData({ folders: existing, folderParents: { Clients: 'Work' } });
+    expect(savedParents()).toEqual({ Clients: 'Personal' });
+  });
+
+  test('an old backup with no nesting map imports everything at the top level', async () => {
+    await mergeImportData({
+      folders: { Dev: [{ title: 'Chat', url: 'https://gemini.google.com/app/abc', timestamp: 1 }] },
+    });
+    expect(savedParents()).toEqual({});
+  });
+
   test('imports pins from backup', async () => {
     const importedData = {
       folders: { Dev: [{ title: 'Chat', url: 'https://gemini.google.com/app/abc', timestamp: 1 }] },


### PR DESCRIPTION
Step 1 of 4 toward sub-folders (one level, root → sub-folder). **Nothing is user-visible yet**: the popup cannot create a nesting and does not render one. This is the storage shape plus every pure helper the later steps go through.

## Data model

```js
folderParents: { [childFolderName]: parentFolderName }   // absent entry = root folder
```

A plain sync key next to `pinnedFolders`. `folders[name]` stays a bare array, so no consumer's `Array.isArray()` assumption breaks and **no migration is needed** — an absent key defaults to `{}` through `loadData`, and an old build ignores the key rather than dropping it.

Child→parent rather than parent→children: a parent→children map can express "this folder has two parents", a child→parent map cannot.

The invariants live in `getFolderParent` / `canNestFolder` / `pruneFolderParents` instead of being re-derived per call site:

- **one level** — the target must be a root folder and the dragged folder must have no children;
- **no cycles** — a two-folder cycle sends both back to the top level instead of looping (the check is deliberately non-recursive);
- **orphans** — a parent deleted on another device makes its child read as a root folder *without* deleting anything: a read must not write, and the parent may come back on the next sync. `pruneFolderParents` does the cleanup on the write side.

Pins are untouched by design: nesting never writes `pinnedFolders`, so a pinned folder keeps its pin dormant while nested and gets it back at the top level. Children are sorted with no pin list so a dormant pin cannot reorder siblings.

## Storage-side changes that belong with it

- **`affectsBookmarks` now fires on `folderParents`.** Nesting rewrites the shape of the mirrored tree while writing no `folders` at all, so without this the bookmark tree would keep the old layout until the next conversation save.
- **`syncToBookmarksTree` mirrors the nesting** instead of flattening it: a sub-folder becomes a real bookmark folder inside its parent, after the parent's own conversations. New optional 4th argument, so existing calls and tests are unchanged.
- **`mergeImportData`** accepts a backup's nesting only when both ends exist in the merged result and depth stays at one; a local placement wins (same policy as the prompt merge), and an old backup imports everything at the top level.

## Tests

`tests/folder-nesting.test.js` — 43 new tests over the pure helpers: orphans, cycles, depth-2 refusal, subtree flattening, subtree-aware root sorting, the dormant-pin rule, the `Parent/Child` path resolver (including a folder literally named `a/b`, which must keep winning over the path reading), the search predicate, and the context-menu model.

Also: nested + orphaned bookmark-tree cases, five `mergeImportData` cases, and `setupStorage` in `tests/folders.test.js` now returns `folderParents` (mechanical, needed by every later step).

## Verification

- `npx jest` — **724 passed** (674 before)
- `python build.py --yes` — OK
- `python tools/validate_build.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
