### PR TITLE
feat(folders): two-level context menu and bulk-move list

### DIFF
--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -115,7 +115,7 @@ async function updateContextMenu() {
       documentUrlPatterns: patterns
     });
 
-    loadData({ folders: {} }, (data) => {
+    loadData({ folders: {}, folderParents: {} }, (data) => {
       const folderNames = Object.keys(data.folders);
 
       if (folderNames.length === 0) {
@@ -127,18 +127,14 @@ async function updateContextMenu() {
           enabled: false
         });
       } else {
-        folderNames.sort().forEach(folder => {
-          const match = folder.match(EMOJI_PREFIX_REGEX);
-          const menuTitle = match
-            ? `${match[1]} ${folder.replace(EMOJI_PREFIX_REGEX, '')}`
-            : `📁 ${folder}`;
-
-          chrome.contextMenus.create({
-            id: `folder_${folder}`,
-            parentId: "ai-folders-parent",
-            title: menuTitle,
-            contexts: ["page"]
-          });
+        // Two levels: a root folder with sub-folders becomes a submenu that
+        // still lets you save into the parent itself. The model is built in
+        // utils.js so this file and its Gemini Folders twin cannot drift.
+        buildContextMenuModel(data.folders, data.folderParents || {}, {
+          rootId: "ai-folders-parent",
+          saveHereTitle: chrome.i18n.getMessage("ctxMenuSave"),
+        }).forEach(item => {
+          chrome.contextMenus.create({ ...item, contexts: ["page"] });
         });
       }
 
@@ -235,8 +231,12 @@ chrome.permissions.onAdded.addListener(async (permissions) => {
   } catch (_) {}
 });
 chrome.storage.onChanged.addListener((changes, namespace) => {
+  // folderParents belongs here: nesting a folder rewrites the second level of
+  // this menu while writing no `folders` at all, so the menu would otherwise
+  // stay stale until the next conversation was saved.
   if (namespace === 'sync' && (changes.folders || changes.foldersDataCompressed
-      || changes.localLlmUrl || Object.keys(changes).some(k => k.startsWith('fdc')))) {
+      || changes.folderParents || changes.localLlmUrl
+      || Object.keys(changes).some(k => k.startsWith('fdc')))) {
     updateContextMenu();
   }
   if (namespace === 'sync' && changes.localLlmUrl) {
@@ -466,11 +466,14 @@ const showToast = (msg, bgColor) => {
 // --- CONTEXT MENU ---
 
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-  if (info.parentMenuItemId !== "ai-folders-parent") return;
+  // Not a parentMenuItemId check any more: a sub-folder's parent is the
+  // `sub_<name>` container, not the root item. The id carries the target, which
+  // is what survives a service-worker restart; `sub_` ids are never save targets.
+  if (typeof info.menuItemId !== 'string' || !info.menuItemId.startsWith('folder_')) return;
   try {
     const { localLlmUrl } = await chrome.storage.sync.get(['localLlmUrl']);
     const siteKey = getSiteByUrl(tab.url, localLlmUrl);
-    const targetFolder = info.menuItemId.replace("folder_", "");
+    const targetFolder = info.menuItemId.slice('folder_'.length);
     const defaultTitle = chrome.i18n.getMessage("defaultTitle") || "New conversation";
     const siteColor = SITES[siteKey]?.color || "#1a73e8";
 

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -33,7 +33,7 @@ function updateContextMenu() {
     });
 
     // Fetch the user's folders
-    loadData({ folders: {} }, (data) => {
+    loadData({ folders: {}, folderParents: {} }, (data) => {
       const folderNames = Object.keys(data.folders);
 
       if (folderNames.length === 0) {
@@ -45,26 +45,14 @@ function updateContextMenu() {
           enabled: false
         });
       } else {
-        // Create a submenu for each folder
-        folderNames.sort().forEach(folder => {
-          const emojiRegex = /^(\p{Emoji_Presentation}|\p{Extended_Pictographic})\s*/u;
-          const match = folder.match(emojiRegex);
-
-          let menuTitle = folder;
-          if (match) {
-            const customIcon = match[1];
-            const displayName = folder.replace(emojiRegex, '');
-            menuTitle = `${customIcon} ${displayName}`;
-          } else {
-            menuTitle = `📁 ${folder}`;
-          }
-
-          chrome.contextMenus.create({
-            id: `folder_${folder}`,
-            parentId: "gemini-folders-parent",
-            title: menuTitle,
-            contexts: ["page"]
-          });
+        // Two levels: a root folder with sub-folders becomes a submenu that
+        // still lets you save into the parent itself. The model is built in
+        // utils.js so this file and its AI Folders twin cannot drift.
+        buildContextMenuModel(data.folders, data.folderParents || {}, {
+          rootId: "gemini-folders-parent",
+          saveHereTitle: chrome.i18n.getMessage("ctxMenuSave"),
+        }).forEach(item => {
+          chrome.contextMenus.create({ ...item, contexts: ["page"] });
         });
       }
 
@@ -137,8 +125,11 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 });
 chrome.runtime.onStartup.addListener(() => { updateContextMenu(); refreshUninstallUrl(); });
 chrome.storage.onChanged.addListener((changes, namespace) => {
+  // folderParents belongs here: nesting a folder rewrites the second level of
+  // this menu while writing no `folders` at all, so the menu would otherwise
+  // stay stale until the next conversation was saved.
   if (namespace === 'sync' && (changes.folders || changes.foldersDataCompressed
-      || Object.keys(changes).some(k => k.startsWith('fdc')))) {
+      || changes.folderParents || Object.keys(changes).some(k => k.startsWith('fdc')))) {
     updateContextMenu();
   }
   // usageStats.opens is bumped on every popup open (src/ui.js) — keep the
@@ -178,9 +169,12 @@ function showToast(msg, bgColor) {
 
 // 3. Listen for menu clicks
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-  if (info.parentMenuItemId === "gemini-folders-parent") {
+  // Not a parentMenuItemId check any more: a sub-folder's parent is the
+  // `sub_<name>` container, not the root item. The id carries the target, which
+  // is what survives a service-worker restart; `sub_` ids are never save targets.
+  if (typeof info.menuItemId === 'string' && info.menuItemId.startsWith('folder_')) {
     try {
-      const targetFolder = info.menuItemId.replace("folder_", "");
+      const targetFolder = info.menuItemId.slice('folder_'.length);
       const fallbackTitle = chrome.i18n.getMessage("defaultTitle") || "New conversation";
 
       const results = await chrome.scripting.executeScript({

--- a/src/bulk-actions.js
+++ b/src/bulk-actions.js
@@ -51,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!targetFolder) return;
     closeDropdown();
 
-    loadData({ folders: {}, openFolders: [] }, (data) => {
+    loadData({ folders: {}, openFolders: [], folderParents: {} }, (data) => {
       let folders    = data.folders;
       let openFolders = data.openFolders;
 
@@ -72,6 +72,10 @@ document.addEventListener('DOMContentLoaded', () => {
       });
 
       if (!openFolders.includes(targetFolder)) openFolders.push(targetFolder);
+      // …and the parent, or conversations moved into a sub-folder land inside a
+      // collapsed folder and look lost.
+      const targetParent = getFolderParent(folders, data.folderParents || {}, targetFolder);
+      if (targetParent && !openFolders.includes(targetParent)) openFolders.push(targetParent);
 
       saveData({ folders: folders, openFolders: openFolders }, () => {
         window.selectedChats = [];
@@ -97,20 +101,32 @@ document.addEventListener('DOMContentLoaded', () => {
       bulkMoveTrigger.textContent = placeholderText();
       bulkMoveList.innerHTML = '';
 
-      loadData({ folders: {} }, (data) => {
-        Object.keys(data.folders).sort().forEach(folder => {
+      loadData({ folders: {}, folderParents: {} }, (data) => {
+        const folderParents = data.folderParents || {};
+
+        const addItem = (folder, isChild) => {
           const match = folder.match(EMOJI_PREFIX_REGEX);
           const icon = match ? match[1] : '📁';
           const displayName = match ? folder.slice(match[0].length) : folder;
 
           const li = document.createElement('li');
-          li.textContent = `${icon} ${displayName}`;
+          // Sub-folders are shown under their parent and marked, but the list
+          // stays FLAT: makeMenuAccessible drives roving focus off
+          // querySelectorAll('li'), so a nested <ul> would break the keyboard.
+          li.textContent = isChild ? `↳ ${icon} ${displayName}` : `${icon} ${displayName}`;
+          if (isChild) li.classList.add('is-child');
           // Focusable and announced: these were click-only <li>, so the folder
           // list was unreachable without a mouse.
           li.setAttribute('role', 'menuitem');
           li.setAttribute('tabindex', '-1');
           li.addEventListener('click', (e) => { e.stopPropagation(); moveTo(folder); });
           bulkMoveList.appendChild(li);
+        };
+
+        getRootFolderNames(data.folders, folderParents).sort().forEach(root => {
+          addItem(root, false);
+          getChildFolders(data.folders, folderParents, root).sort()
+            .forEach(child => addItem(child, true));
         });
       });
     } else {

--- a/src/popup.css
+++ b/src/popup.css
@@ -828,6 +828,11 @@
     .custom-dropdown-list li:hover {
       background: var(--folder-hover);
     }
+    /* Sub-folders in the bulk-move list: indented, but still plain <li> siblings
+       — makeMenuAccessible walks a flat querySelectorAll('li'). */
+    .custom-dropdown-list li.is-child {
+      padding-inline-start: 24px;
+    }
     .custom-dropdown-list li:first-child { border-radius: 4px 4px 0 0; }
     .custom-dropdown-list li:last-child  { border-radius: 0 0 4px 4px; }
 

--- a/tests/bulk-actions.test.js
+++ b/tests/bulk-actions.test.js
@@ -20,12 +20,13 @@ function mountDOM() {
   document.dispatchEvent(new Event('DOMContentLoaded'));
 }
 
-function setStorage(folders) {
+function setStorage(folders, folderParents = {}) {
   global.loadData = jest.fn((defaults, cb) =>
     cb({
       folders: JSON.parse(JSON.stringify(folders)),
       openFolders: [],
       pinnedFolders: [],
+      folderParents: { ...folderParents },
     })
   );
   global.saveData = jest.fn((data, cb) => cb && cb());
@@ -41,6 +42,10 @@ const flush = () => new Promise((r) => setTimeout(r, 0));
 beforeEach(() => {
   global.normalizeUrl = jest.fn((u) => u.split('?')[0].split('#')[0]);
   global.EMOJI_PREFIX_REGEX = EMOJI_PREFIX_REGEX;
+  const utils = require('../src/utils');
+  for (const name of ['getRootFolderNames', 'getChildFolders', 'getFolderParent']) {
+    global[name] = utils[name];
+  }
   global.window.displayFolders = jest.fn();
   global.window.showCustomModal = jest.fn();
   global.window.selectedChats = [];
@@ -111,6 +116,37 @@ describe('move (clicking a destination folder)', () => {
       .click();
 
     expect(lastSavedFolders().Dst).toHaveLength(1);
+  });
+});
+
+describe('sub-folders in the move list', () => {
+  test('children are listed under their parent, marked, and the list stays flat', () => {
+    setStorage({ Work: [], Clients: [], Personal: [] }, { Clients: 'Work' });
+    window.selectedChats = [{ folder: 'Personal', url: 'https://a/1', chatObj: {} }];
+
+    window.updateBulkActionBar();
+
+    const items = [...document.querySelectorAll('#bulkMoveList li')];
+    expect(items.map((li) => li.textContent)).toEqual(['📁 Personal', '📁 Work', '↳ 📁 Clients']);
+    expect(items[2].classList.contains('is-child')).toBe(true);
+    // Flat: makeMenuAccessible drives roving focus off querySelectorAll('li').
+    expect(document.querySelectorAll('#bulkMoveList ul')).toHaveLength(0);
+    expect(items.every((li) => li.getAttribute('role') === 'menuitem')).toBe(true);
+  });
+
+  test('moving into a sub-folder expands its parent too', async () => {
+    setStorage({ Work: [], Clients: [], Personal: [{ title: 'c', url: 'https://a/1' }] },
+      { Clients: 'Work' });
+    window.selectedChats = [{ folder: 'Personal', url: 'https://a/1', chatObj: { title: 'c', url: 'https://a/1' } }];
+    window.updateBulkActionBar();
+
+    [...document.querySelectorAll('#bulkMoveList li')]
+      .find((li) => li.textContent.includes('Clients')).click();
+    await flush();
+
+    const saved = global.saveData.mock.calls[global.saveData.mock.calls.length - 1][0];
+    expect(saved.folders.Clients).toHaveLength(1);
+    expect(saved.openFolders).toEqual(expect.arrayContaining(['Clients', 'Work']));
   });
 });
 


### PR DESCRIPTION
Step 3 of 4 for sub-folders. Same content as #65, which GitHub auto-closed when its base branch (`feat/nested-folders-ui`) was deleted by the #64 merge — reopening a PR whose base is gone is not allowed, so this replaces it. Now based on `main`, so CI runs and the diff is just this step.

The two entry points outside the folder list still treated sub-folders as top-level folders. David hit both while testing.

## Right-click menu

```
Save to AI Folders
├─ 📁 Personal                     folder_Personal      ← leaf root, unchanged
└─ 🗂️ Work                         sub_Work             ← submenu container
   ├─ Save to AI Folders           folder_Work          ← the parent itself, still selectable
   ├─ ──────                       separator
   ├─ 📁 Clients                   folder_Clients
   └─ 📁 Research                  folder_Research
```

A `contextMenus` item that has children is not clickable on its own, hence the explicit first entry — it reuses `ctxMenuSave`, so **no new string**.

**Ids stay `folder_<name>` at both levels.** Folder names are unique keys of one flat object, so the id already identifies the target unambiguously *and* survives a service-worker restart — unlike an index into a lookup table rebuilt on every menu refresh. Only the submenu containers take a `sub_` prefix, which the click handler never accepts as a save target. The old `parentMenuItemId === "…-parent"` guard had to go: a sub-folder's parent is now its container.

The model is built by `buildContextMenuModel` in `utils.js`. The two `background.js` stay unshared (CLAUDE.md §6) but can no longer drift, and the shape is unit-testable — which matters because neither file has a test suite of its own.

Both copies now also rebuild on a **`folderParents` change**: nesting writes no `folders`, so the second level would otherwise stay stale until the next conversation was saved.

## Bulk move

Children are listed under their parent with a `↳` marker and an indent, and moving into one expands the parent. The list stays **flat** — `makeMenuAccessible` drives roving focus off `querySelectorAll('li')`, so a nested `<ul>` would break keyboard access.

## Verification

- `npx jest` — **763 passed**, including the menu-model tests from #63 and two new bulk-list ones.
- `python build.py --yes` + `python tools/validate_build.py` — OK.
- Needs real eyes: the right-click menu on a supported site, in **both** extensions and **both** browsers (nested `menus` entries and `separator` on Firefox), since `background.js` has no automated coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
