### PR TITLE
fix(folders): say so when a folder name is already taken

### DIFF
--- a/src/popup-core.js
+++ b/src/popup-core.js
@@ -286,13 +286,22 @@ function initPopupCommon(config) {
         return;
       }
       loadData({ folders: {} }, (data) => {
-        if (!hasEntry(data.folders, name.trim())) {
-          data.folders[name.trim()] = [];
-          saveData({ folders: data.folders }, (err) => {
-            if (err) { window.showCustomModal({ title: chrome.i18n.getMessage("storageFullError") || '⚠️ Storage full — not saved.', type: 'alert' }); return; }
-            if (window.displayFolders) window.displayFolders();
+        // Say so, instead of closing the modal as if it had worked. Same refusal
+        // and same message as renaming onto an existing name (folders.js).
+        // Folder names are one flat namespace, so this also catches a name taken
+        // by a sub-folder — which the user may not see at the top level.
+        if (hasEntry(data.folders, name.trim())) {
+          window.showCustomModal({
+            title: chrome.i18n.getMessage("errorFolderExists") || "A folder with this name already exists.",
+            type: 'alert',
           });
+          return;
         }
+        data.folders[name.trim()] = [];
+        saveData({ folders: data.folders }, (err) => {
+          if (err) { window.showCustomModal({ title: chrome.i18n.getMessage("storageFullError") || '⚠️ Storage full — not saved.', type: 'alert' }); return; }
+          if (window.displayFolders) window.displayFolders();
+        });
       });
     }
   });

--- a/tests/popup-core.test.js
+++ b/tests/popup-core.test.js
@@ -313,3 +313,105 @@ describe('initSaveConversation', () => {
     expect(global.saveData).toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// New folder button
+// ---------------------------------------------------------------------------
+
+// Creating a folder whose name was taken used to do nothing at all — the modal
+// closed as if it had worked. What is worth locking down is that the refusal is
+// now visible AND that nothing is written, since silence was the whole bug.
+describe('new folder button', () => {
+  // Every id initPopupCommon dereferences; same fixture style as applyCommonI18n.
+  const IDS = [
+    'newFolderBtn', 'searchInput', 'sortToggleBtn', 'sortMenu', 'modeFolderBtn',
+    'modePromptBtn', 'folderModeContainer', 'promptModeContainer', 'promptSearchInput',
+    'toggleAddPanelBtn', 'addConversationPanel', 'exportBtn', 'importBtn', 'importFile',
+    'syncBookmarksToggle', 'syncBookmarksLabel', 'syncPromptsLabel', 'githubLink', 'kofiBtn',
+  ];
+
+  let modals;
+
+  function wire(folders) {
+    modals = [];
+    document.body.innerHTML = IDS.map((id) => `<div id="${id}"></div>`).join('');
+    global.loadData = jest.fn((defaults, cb) => cb({ folders: JSON.parse(JSON.stringify(folders)) }));
+    global.saveData = jest.fn((data, cb) => cb && cb());
+    global.window.displayFolders = jest.fn();
+    global.window.displayPrompts = jest.fn();
+    // The prompt returns whatever the test typed; alerts are recorded.
+    global.window.showCustomModal = jest.fn((opts) => {
+      modals.push(opts);
+      return Promise.resolve(opts.type === 'prompt' ? typed : true);
+    });
+    chrome.storage.sync.get = jest.fn((_keys, cb) => cb && cb({}));
+    chrome.storage.sync.set = jest.fn((_v, cb) => cb && cb());
+    window.initPopupCommon({});
+  }
+
+  let typed = '';
+  const alerts = () => modals.filter((m) => m.type === 'alert').map((m) => m.title);
+
+  async function typeName(name, folders) {
+    typed = name;
+    wire(folders);
+    // initPopupCommon renders once while wiring; clear so every assertion below
+    // is about what the click did.
+    global.saveData.mockClear();
+    window.displayFolders.mockClear();
+    modals = [];
+    document.getElementById('newFolderBtn').click();
+    await flush();
+  }
+
+  test('a free name creates the folder and re-renders', async () => {
+    await typeName('Ideas', { Dev: [] });
+
+    expect(global.saveData).toHaveBeenCalled();
+    expect(Object.keys(global.saveData.mock.calls[0][0].folders)).toEqual(['Dev', 'Ideas']);
+    expect(window.displayFolders).toHaveBeenCalled();
+    expect(alerts()).toEqual([]);
+  });
+
+  test('a name already taken is refused, and nothing is written', async () => {
+    await typeName('Dev', { Dev: [] });
+
+    expect(alerts()).toEqual(['errorFolderExists']);
+    // The bug was silence, so the absence of a write is the thing to assert.
+    expect(global.saveData).not.toHaveBeenCalled();
+    expect(window.displayFolders).not.toHaveBeenCalled();
+  });
+
+  test('a name taken by a SUB-folder is refused the same way', async () => {
+    // Folder names are one flat namespace, so the collision is real even though
+    // the other folder is nested out of sight under its parent.
+    await typeName('Bugs', { Dev: [], Bugs: [] });
+
+    expect(alerts()).toEqual(['errorFolderExists']);
+    expect(global.saveData).not.toHaveBeenCalled();
+  });
+
+  test('an inherited name is a usable folder title, not a collision', async () => {
+    // folders['toString'] is truthy on every object; hasEntry is what makes this
+    // an ordinary name rather than a permanent "already exists".
+    await typeName('toString', { Dev: [] });
+
+    expect(alerts()).toEqual([]);
+    expect(global.saveData.mock.calls[0][0].folders.toString).toEqual([]);
+  });
+
+  test('__proto__ still gets the reserved-name message, not the collision one', async () => {
+    await typeName('__proto__', { Dev: [] });
+
+    expect(alerts()).toEqual(['reservedNameError']);
+    expect(global.saveData).not.toHaveBeenCalled();
+  });
+
+  test.each([['a cancelled prompt', null], ['a whitespace-only name', '   ']])(
+    '%s does nothing, silently', async (_label, value) => {
+      await typeName(value, { Dev: [] });
+
+      expect(alerts()).toEqual([]);
+      expect(global.saveData).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Creating a folder with a name that already existed did **nothing at all**: `if (!hasEntry(folders, name)) { create }` had no `else`, so the modal closed as if it had worked and the user went looking for a folder that was never created.

Renaming onto an existing name has always refused with a message. This is the same refusal, missing in the one place people meet it first — and it **reuses `errorFolderExists`**, already translated in 43 locales × 2 extensions, so there is nothing new to translate.

## Scope, as agreed

- **Plain alert**, exactly like the rename path — the prompt does not reopen pre-filled, which would make the two flows diverge.
- **Exact duplicates only.** "Dev" and "dev" stay two distinct folders: that is visible on screen, so it was never a silent failure, and changing it would mean changing rename and the save box too, plus deciding what happens to pairs already in people's data.

## What the tests pin down

Beyond the message itself, two properties that matter more than it:

- **The refusal writes nothing.** Silence was the whole bug, so the absence of a save is the assertion that counts.
- **A name taken by a sub-folder is refused too** — folder names are one flat namespace, so the collision is real even when the other folder sits nested out of sight under a parent.

Plus the guards that were already there and must not drift: `__proto__` keeps its own `reservedNameError`, a folder called `toString` stays an ordinary title (`hasEntry`, not truthiness — CLAUDE.md §6), and cancelling or typing only spaces still does nothing without an alert.

Both new refusal tests were checked against the old behaviour restored on purpose: they fail when they should.

## Verification

- `npx jest` — **808 passed** (801 before), 7 new
- `python build.py --yes` + `python tools/validate_build.py` — OK

Worth a quick look in the popup: ➕ 📁 with an existing name, then with a free one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
