### PR TITLE
fix(store-publisher): stop walking 43 languages for a global-only run

### DIFF
--- a/tests/store-publisher/locales.test.js
+++ b/tests/store-publisher/locales.test.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const {
   LOCALES, promoTxtName, screenshotName, SCREENSHOTS_PER_LOCALE, filterLocales,
+  needsLocaleWalk,
 } = require('../../tools/store-publisher/lib/locales');
 
 describe('store-publisher locales', () => {
@@ -87,6 +88,28 @@ describe('store-publisher locales', () => {
     test('unknown locales throw', () => {
       expect(() => filterLocales('xx')).toThrow(/Unknown locale/);
       expect(() => filterLocales('from:xx')).toThrow(/Unknown locale/);
+    });
+  });
+
+  // The international screenshots live in the language-independent "Global
+  // assets" card. A run that only replaces them must not walk the 43 languages:
+  // besides the wasted ~2 min, one unconfirmed language switch aborts the run
+  // before the global step it was asked to perform.
+  describe('needsLocaleWalk', () => {
+    test('true when a per-language step is selected', () => {
+      expect(needsLocaleWalk({ updateTexts: true })).toBe(true);
+      expect(needsLocaleWalk({ updateImages: true })).toBe(true);
+      expect(needsLocaleWalk({ updateTexts: true, updateImages: true })).toBe(true);
+      expect(needsLocaleWalk({ updateTexts: true, updateGlobalImages: true })).toBe(true);
+    });
+
+    test('false for international screenshots alone', () => {
+      expect(needsLocaleWalk({ updateGlobalImages: true })).toBe(false);
+    });
+
+    test('false when nothing is selected', () => {
+      expect(needsLocaleWalk({})).toBe(false);
+      expect(needsLocaleWalk(undefined)).toBe(false);
     });
   });
 });

--- a/tools/store-publisher/README.md
+++ b/tools/store-publisher/README.md
@@ -57,11 +57,16 @@ Open the popup:
 - **Replace the 5 localized screenshots per locale** — deletes the existing
   ones then uploads `Promo_1..5_<locale>.png` in order.
 - **Replace international screenshots with EN set** — the global (non-localized)
-  screenshot slots; needed once per deployment only.
+  screenshot slots; needed once per deployment only. Ticked on its own it skips
+  the language walk entirely: that card is language-independent, so there is
+  nothing to select. (It used to switch through all 43 languages first, which
+  wasted ~2 min and could abort the run on an unconfirmed switch before ever
+  reaching the global card.)
 - **Dry run** — walks the 43 languages and locates every field/section without
   writing anything. **Run this first on a new console layout.**
 - **Locale filter** — empty = all; `fr,de` = just those; `from:pl` = resume an
-  aborted run at `pl`.
+  aborted run at `pl`. Ignored (with a log line) when no per-language step is
+  ticked. Ticking nothing at all is refused up front rather than opening a tab.
 - **Probe page** — opens the listing page and dumps its DOM structure
   (dropdowns, textareas, file inputs, sections, buttons) to the log. This is
   the debugging entry point when Google changes the page.

--- a/tools/store-publisher/background.js
+++ b/tools/store-publisher/background.js
@@ -213,7 +213,18 @@ async function runPublish(config, opts, onProgress) {
   const item = config.items.find(i => i.slug === opts.itemSlug);
   if (!item) throw new Error(`Item "${opts.itemSlug}" not in config.json`);
 
+  // Nothing ticked would open a tab, walk 43 languages and write nothing.
+  if (!opts.probeOnly && !opts.updateTexts && !opts.updateImages && !opts.updateGlobalImages) {
+    throw new Error('Nothing selected — tick at least one of the description / localized '
+      + 'screenshots / international screenshots options, or use "Probe page".');
+  }
+
+  const walkLocales = needsLocaleWalk(opts);
+  // Parsed even when unused, so a bad filter is still rejected up front.
   const locales = filterLocales(opts.localeFilter);
+  if (!walkLocales && opts.localeFilter) {
+    onProgress(`Locale filter "${opts.localeFilter}" ignored — no per-language step selected.`);
+  }
   // Resolved lazily: a pure probe touches no local file, so it must keep working
   // even when the native host is unregistered (e.g. right after a repo move).
   let marketingDir = null;
@@ -259,14 +270,23 @@ async function runPublish(config, opts, onProgress) {
     return;
   }
 
-  for (const locale of locales) {
-    try {
-      await publishLocale(driver, tab.id, locale, texts[locale.internal], opts, marketingDir, onProgress);
-    } catch (e) {
-      if (e.detail) onProgress('Diagnostics: ' + fmtDetail(e.detail));
-      onProgress(`Aborted at locale "${locale.internal}". Fix the issue (see stores/${driver.id}.js), then resume with filter "from:${locale.internal}".`);
-      throw e;
+  // The language walk is only for what lives behind the language dropdown: the
+  // description and the "Localized assets" screenshots. Skipping it when neither
+  // is selected is not just a speed-up — a single unconfirmed language switch
+  // throws, and the global block below sits *after* this loop, so a global-only
+  // run could abort before ever reaching what it was asked to do.
+  if (walkLocales) {
+    for (const locale of locales) {
+      try {
+        await publishLocale(driver, tab.id, locale, texts[locale.internal], opts, marketingDir, onProgress);
+      } catch (e) {
+        if (e.detail) onProgress('Diagnostics: ' + fmtDetail(e.detail));
+        onProgress(`Aborted at locale "${locale.internal}". Fix the issue (see stores/${driver.id}.js), then resume with filter "from:${locale.internal}".`);
+        throw e;
+      }
     }
+  } else {
+    onProgress('No per-language step selected — skipping the language walk.');
   }
 
   // International / global screenshots: the "Global assets" card on the same

--- a/tools/store-publisher/lib/locales.js
+++ b/tools/store-publisher/lib/locales.js
@@ -96,6 +96,18 @@ function filterLocales(filterText) {
   return result;
 }
 
+// Which options require walking the language dropdown. The detailed
+// description and the "Localized assets" screenshots are per-language; the
+// international screenshots live in the language-independent "Global assets"
+// card, so a global-only run has nothing to select and must not spend ~2 min
+// switching languages it will not write to.
+function needsLocaleWalk(opts) {
+  return !!(opts && (opts.updateTexts || opts.updateImages));
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = { LOCALES, promoTxtName, screenshotName, SCREENSHOTS_PER_LOCALE, filterLocales };
+  module.exports = {
+    LOCALES, promoTxtName, screenshotName, SCREENSHOTS_PER_LOCALE,
+    filterLocales, needsLocaleWalk,
+  };
 }


### PR DESCRIPTION
Ticking only **Replace international screenshots** still switched the CWS console through all 43 languages first, writing nothing in any of them.

Two wasted minutes is the visible cost. The real one is the failure mode: `publishLocale` throws when a language switch comes back unconfirmed (`background.js:182-184`), and the Global assets block sits *after* the loop — so a run asked to touch one language-independent card could abort before ever reaching it.

The international screenshots live in the "Global assets" card, which the language dropdown does not affect. Only the detailed description and the "Localized assets" screenshots are per-language, so the walk is now guarded on those two. The intent already existed one function up: the pre-flight has always spot-checked `en` when `updateImages` is off.

Two smaller holes closed while in there:

- A locale filter left in the field — a `from:pl` from an aborted run — now says it is being ignored, instead of looking like it applies.
- Ticking nothing at all is refused up front rather than opening a tab to do nothing.

The decision is a pure function (`needsLocaleWalk`) in `lib/locales.js` so it can be tested; `background.js` has no coverage and is not requireable.

## Verification

- `npx jest` — 811 passing, including 3 new cases pinning that international-only is `false` and each per-language option is `true`.
- Manual, temporary add-on in Firefox: with only **Replace international screenshots** + **Dry run** ticked, the log goes from `Opening …` straight to `International screenshots (Global assets) → EN set…`, with no `xx (Language)` lines.
- Regression: **Update detailed descriptions** with filter `fr,de` still walks both locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
