### PR TITLE
chore(store-publisher): publish the package by API, not by hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -668,8 +668,47 @@ id, the AMO API secret, and `assets.root`, the path to this checkout.
   existed for the publisher and were removed with it, and its manifest no longer
   allowlists that add-on's id. The publisher ships its own host, confined to
   directories its installer records.
-- **Release order is unchanged:** upload the build zip by hand, `python
-  build.py`, run the publisher one extension at a time, then review and click
-  **Save draft** yourself. The CWS side never saves. The AMO side has no draft
-  stage at all — `amo_publish.py` is dry-run by default and `--apply` writes
-  live.
+
+### 12b. Release order
+
+The Chrome Web Store **does** have an API (v2), and the publisher uses it for
+the package and the publication lifecycle. It has **none** for the listing, so
+step 3 is not a step waiting to be automated — see below.
+
+```
+1. python build.py                                           # dist/ is the input to everything
+2. python cws/cws_publish.py --item <slug> --upload --apply   # uploads the zip → CWS draft
+3. the add-on fills the localized listing draft; Save draft by hand
+4. python cws/cws_publish.py --item <slug> --publish --apply  # submit for review
+5. python cws/cws_publish.py --item <slug> --status           # watch the review
+```
+
+Firefox is symmetric and entirely API-driven:
+
+```
+python amo/amo_publish.py --item <slug> --upload-version --apply
+python amo/amo_publish.py --item <slug> --texts --images --apply
+```
+
+- **`python build.py` is a hard prerequisite, not a build step.** Every path the
+  publisher reads is under `dist/`: the promo texts with their Firefox wording
+  patches, the screenshots, the `_locales` the AMO summary and name come from,
+  and the zips themselves.
+- **The CWS API cannot touch the listing.** Its discovery document defines five
+  methods (`media.upload`, `publish`, `fetchStatus`, `cancelSubmission`,
+  `setPublishedDeployPercentage`) and no field for a description, a screenshot
+  or a category; the official guide says the Store listing tab must be filled in
+  the dashboard. Step 3 will not disappear by automating harder. Don't go
+  looking for that API again — it is not in v1 either, and v1 sunsets
+  15/10/2026.
+- **Everything is dry-run by default**; `--apply` writes. Run without it first:
+  a dry-run of a CWS write makes no API call and needs no credentials, so it is
+  a free check that the package path resolved to the zip you just built.
+- **The AMO side has no draft stage** — listing edits go live the moment
+  `--apply` lands. The CWS side never saves at all; **Save draft** stays manual.
+- `--staged` holds a CWS release after approval so GF and AF can go out
+  together; `--rollout N` raises the percentage afterwards without a re-review.
+- **`store-publisher.config.json` carries the package templates**
+  (`dist/{slug}-chrome-v{version}.zip`) and a `versionSource` pointing at the
+  built manifest, so the version in the filename cannot disagree with the bytes.
+  Credentials and `assets.root` live in the tool's own gitignored config.

--- a/store-publisher.config.json
+++ b/store-publisher.config.json
@@ -19,12 +19,22 @@
     "chrome": {
       "description": "dist/{slug}/marketing_chrome/Promo{LANG}.txt",
       "screenshot": "dist/{slug}/marketing_chrome/screenshots/Promo_{n}_{lang}.png",
-      "screenshotsPerListing": 5
+      "screenshotsPerListing": 5,
+      "package": "dist/{slug}-chrome-v{version}.zip",
+      "versionSource": {
+        "path": "dist/{slug}/chrome/manifest.json",
+        "key": "version"
+      }
     },
     "firefox": {
       "description": "dist/{slug}/marketing_firefox/Promo{LANG}.txt",
       "screenshot": "dist/{slug}/marketing_firefox/screenshots/Promo_{n}_{lang}.png",
-      "screenshotsPerListing": 5
+      "screenshotsPerListing": 5,
+      "package": "dist/{slug}-firefox-v{version}.zip",
+      "versionSource": {
+        "path": "dist/{slug}/firefox/manifest.json",
+        "key": "version"
+      }
     }
   },
   "amo": {

--- a/tests/store-publisher-config.test.js
+++ b/tests/store-publisher-config.test.js
@@ -79,6 +79,52 @@ describe('store-publisher.config.json', () => {
     }
   });
 
+  // The publisher uploads the package through each store's API, so it has to be
+  // able to find the zip build.py emits. {version} is read from the BUILT
+  // manifest, which is what stops the version in the filename from disagreeing
+  // with the bytes inside it.
+  test('the package templates match what build.py emits', () => {
+    for (const store of ['chrome', 'firefox']) {
+      const profile = config.assets[store];
+      expect(profile.package).toBe(`dist/{slug}-${store}-v{version}.zip`);
+      expect(profile.versionSource).toEqual({
+        path: `dist/{slug}/${store}/manifest.json`, key: 'version',
+      });
+    }
+  });
+
+  // Not a style check: a template that lost {version} or {slug} would resolve to
+  // one path for every item and release, and upload whichever build was there.
+  test('every package template keeps the placeholders that make it specific', () => {
+    for (const store of ['chrome', 'firefox']) {
+      expect(config.assets[store].package).toContain('{slug}');
+      expect(config.assets[store].package).toContain('{version}');
+      expect(config.assets[store].versionSource.path).toContain('{slug}');
+    }
+  });
+
+  // The string comparison above only says the config still says what it said.
+  // This binds it to the code that actually names the files: rename the zip in
+  // build.py and the publisher would look for a file that is never written.
+  describe('bound to what build.py actually emits', () => {
+    const buildPy = fs.readFileSync(path.join(ROOT, 'build.py'), 'utf8');
+
+    test('build.py still names the zips <prefix>-<browser>-v<version>.zip', () => {
+      for (const store of ['chrome', 'firefox']) {
+        expect(buildPy).toContain(
+          `f"{cfg['zip_prefix']}-${store}-v{version}.zip"`);
+      }
+    });
+
+    // The templates use {slug}; build.py uses zip_prefix. They are only
+    // interchangeable while those two strings agree, for every item.
+    test('each item’s slug is its zip_prefix in build.py', () => {
+      for (const item of config.items) {
+        expect(buildPy).toContain(`"zip_prefix":         "${item.slug}"`);
+      }
+    });
+  });
+
   // assets.root is the one machine-dependent value, so it belongs in the
   // operator's own gitignored config, not in a file the repo commits.
   test('no machine-specific path and no credential is committed here', () => {


### PR DESCRIPTION
The Chrome Web Store has an API after all — a **v2** one — and the publisher now uses it for the package and the publication lifecycle. Two steps §12 described as manual (upload the zip, click publish) become commands, and staged rollout and review-watching stop requiring the dashboard. Firefox gains the symmetric half via AMO's version-upload API.

Tool side: https://github.com/dlamarre-dev/store-listing-publisher/pull/1 (merged)

## What changes here

`store-publisher.config.json` gains a package template per store plus a `versionSource` pointing at the **built** manifest, so the version in the filename cannot disagree with the bytes inside it. Credentials and `assets.root` stay in the tool's own gitignored config.

`CLAUDE.md` §12 gains a release-order section:

```
1. python build.py
2. cws_publish.py --item <slug> --upload --apply    ← was manual
3. the add-on fills the localized listing draft; Save draft by hand
4. cws_publish.py --item <slug> --publish --apply   ← was manual
5. cws_publish.py --item <slug> --status
```

## The thing worth not rediscovering

**The CWS API has no listing metadata.** Its [discovery document](https://chromewebstore.googleapis.com/$discovery/rest?version=v2) defines five methods and not one field for a description, a screenshot or a category; `publishers.items` reports "no persistent data"; and the [official guide](https://developer.chrome.com/docs/webstore/using-api) says the Store listing tab must be filled in the dashboard.

So step 3 will not disappear by automating harder, and §12 now says so. It is not in v1 either — which sunsets **15 October 2026**.

## Tests that bind rather than restate

The new cases tie the config to the code that actually names the files:

- `build.py`'s own f-strings must still produce `<zip_prefix>-<browser>-v<version>.zip`.
- Every item's `slug` must still be its `zip_prefix`, since the templates use one and `build.py` the other — they are only interchangeable while those agree.

Checked in **both directions** by breaking each on purpose: dropping `{version}` from the config fails two tests, renaming the zip in `build.py` fails a third. `build.py` was restored afterwards (no diff in this PR).

## Verification

- `npx jest` — 810 passing (23 suites).
- `python build.py --yes` then `python tools/validate_build.py` — both clean.
- Both publisher halves dry-run against the freshly built `dist/`, resolving the real zips (`gemini-folders-chrome-v4.6.0.zip`) and, on AMO, the listing's actual `MIT` license.
- Not verified: the CWS API calls themselves. That needs a service account granted in the Developer Dashboard; `--status` is the read-only first call that proves the auth end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
