### PR TITLE
feat(build): add Microsoft Edge as a third store target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ the codebase. Keep it accurate: update it when procedures or constraints change.
 
 ## 1. What this repository is
 
-Two Manifest V3 browser extensions (Chrome **and** Firefox) that organize AI
+Two Manifest V3 browser extensions (Chrome, Edge **and** Firefox) that organize AI
 conversations into folders and provide a reusable prompt library:
 
 - **Gemini Folders (GF)** — Google Gemini only. Current version **4.6.0**.
@@ -129,12 +129,12 @@ the second case tells you even less than the first. Only `--force` continues.
 ```bash
 python tools/validate_build.py   # after build.py; exits 1 and lists every problem
 ```
-Checks the four built manifests (version, **permission drift**, no `"tabs"`,
+Checks the six built manifests (version, **permission drift**, no `"tabs"`,
 Firefox gecko id), 43 locales with parseable `messages.json`, no unresolved
 `__PLACEHOLDER__`, and that each ZIP has a root manifest, `_locales`, and no
 `tools/`/`Marketing/`/`tests/` files. Run by CI's `build` job.
 The build copies `src/` then overlays `extensions/<name>/` into
-`dist/<name>/{chrome,firefox}`, patches the manifest + locales for Firefox, and
+`dist/<name>/{chrome,edge,firefox}`, patches the manifest + locales per target, and
 emits versioned `.zip` files. `dist/` is gitignored.
 
 **Manual load (dev mode):**
@@ -142,6 +142,28 @@ emits versioned `.zip` files. `dist/` is gitignored.
   `dist/ai-folders/chrome/` or `dist/gemini-folders/chrome/`.
 - Firefox: `about:debugging` → This Firefox → Load Temporary Add-on →
   `manifest.json` inside `dist/<name>/firefox/`.
+- Edge: `edge://extensions` → Developer mode → Load unpacked → `dist/<name>/edge/`.
+
+**Adding a store target is a row in `TARGETS` (build.py), not a fourth build
+function.** `build_chrome` and `build_firefox` used to be two ~90 %-identical
+functions; everything that differs is now data — destination directory, zip
+suffix, files to drop, text swaps, and an optional manifest patcher. Three things
+follow from that and are easy to get wrong:
+
+- **Edge keeps `Ctrl+Shift+S`** (it shares Chrome's `commands` API) and gets no
+  gecko id. Its only swap is `Chrome` → `Microsoft Edge`, which is what
+  Microsoft's certification requires: *"If Chrome is used in either the name or
+  the description of your extension, rebrand the extension using Microsoft
+  Edge."* A brand swap is language-independent, exactly like the Firefox one.
+- **`review_url_<target>` and `af_download_url_<target>` may be empty**, because
+  a store URL only exists once the listing is published. `inject_popup_urls`
+  then *removes* the block that would link nowhere (`strip_block`) rather than
+  ship a dead link or an unsubstituted `__REVIEW_URL__`; `build_marketing` drops
+  the promo line carrying an unresolved `__AF_STORE_URL__` for the same reason.
+  Filling the URL in brings both back on the next build — nothing to remember.
+- **`validate_build.py` now also walks `marketing_<target>/`.** It never did, and
+  that was survivable only while every promo placeholder was always substituted.
+  A promo file is store copy: a placeholder left in one is read by users.
 
 ---
 

--- a/build.py
+++ b/build.py
@@ -32,8 +32,14 @@ EXTENSION_CONFIG = {
         "marketing_subdir":   "gemini-folders",
         "review_url_chrome":       "https://chromewebstore.google.com/detail/gemini-folders/jffchdehoapigpmifkmleglfimjiilik/reviews",
         "review_url_firefox":      "https://addons.mozilla.org/firefox/addon/gemini_folders/reviews/",
+        # Empty until the Edge listing is published: the public URL carries an id
+        # Partner Center only assigns at publish time. An empty review URL makes
+        # build_target drop the banner rather than ship a dead link (see
+        # strip_review_banner); filling it in brings the banner back by itself.
+        "review_url_edge":         "",
         "af_download_url_chrome":  "https://chromewebstore.google.com/detail/ai-folders/kjmgfajofolnfeaahchpmkpecfimcppf",
         "af_download_url_firefox": "https://addons.mozilla.org/firefox/addon/ai_folders/",
+        "af_download_url_edge":    "",
     },
     "ai-folders": {
         "firefox_gecko_id":   "aifolders@dlamarre-dev.github.io",
@@ -43,6 +49,59 @@ EXTENSION_CONFIG = {
         "marketing_subdir":   "ai-folders",
         "review_url_chrome":  "https://chromewebstore.google.com/detail/ai-folders/kjmgfajofolnfeaahchpmkpecfimcppf/reviews",
         "review_url_firefox": "https://addons.mozilla.org/firefox/addon/ai_folders/reviews/",
+        "review_url_edge":    "",
+    },
+}
+
+# Spellings of the quick-save shortcut as they appear in translated strings and
+# promo texts. Firefox cannot bind Ctrl+Shift+S, so it swaps all of them.
+QUICK_SAVE_SPELLINGS = ["Ctrl+Shift+S", "Cmd+Shift+S", "Command+Shift+S",
+                        "⌘+Shift+S", "Strg+Shift+S"]
+
+# --- BUILD TARGETS ---
+# One entry per store target. Everything that differs between the builds lives
+# here as data, so build_target() is a single code path: adding a fourth store
+# means adding a row, not a fourth near-copy of the same 90 lines.
+#
+#   emoji / label     log lines only
+#   drop_files        which config key lists files to remove from the merged tree
+#   text_swaps        (old, new) pairs applied to _locales AND the promo texts
+#   collapse_mac      drop the now-redundant "(or X on Mac)" parenthetical
+#   patch_manifest    optional callable(manifest, dest, cfg)
+#
+# The per-target URLs are read as review_url_<target> / af_download_url_<target>.
+TARGETS = {
+    "chrome": {
+        "emoji": "🚀",
+        "label": "Chrome",
+        "drop_files": "firefox_only_files",
+        "text_swaps": [],
+        "collapse_mac": False,
+        "patch_manifest": None,
+    },
+    "edge": {
+        "emoji": "🌊",
+        "label": "Edge",
+        "drop_files": "firefox_only_files",
+        # Microsoft's port guide is explicit: "If Chrome is used in either the
+        # name or the description of your extension, rebrand the extension using
+        # Microsoft Edge. To pass the certification process, the changes are
+        # required." A brand swap is language-independent, exactly like Firefox's.
+        # The quick-save shortcut is NOT swapped: Edge shares Chrome's commands API.
+        "text_swaps": [("Chrome", "Microsoft Edge")],
+        "collapse_mac": False,
+        "patch_manifest": None,
+    },
+    "firefox": {
+        "emoji": "🦊",
+        "label": "Firefox",
+        # Firefox keeps import.html/js/css: it cannot open a file picker from a
+        # popup, so the standalone import page is its only route (src/popup-core.js).
+        "drop_files": None,
+        "text_swaps": ([("Chrome", "Firefox")]
+                       + [(sc, "Alt+Shift+S") for sc in QUICK_SAVE_SPELLINGS]),
+        "collapse_mac": True,
+        "patch_manifest": "firefox",
     },
 }
 
@@ -199,66 +258,61 @@ def run_tests(assume_yes=False, force=False):
 # Extension builds
 # ---------------------------------------------------------------------------
 
-def build_chrome(ext_name, version):
-    cfg = EXTENSION_CONFIG[ext_name]
-    print(f"🚀 [{cfg['display_name']}] Building Chrome...")
+def strip_block(html, element_id):
+    """Removes a whole `<div id="...">...</div>` block from popup.html.
 
-    dest = os.path.join(DIST_DIR, ext_name, "chrome")
-    merge_into(SRC_DIR, ext_dir(ext_name), dest)
+    Used when a target has no URL for what the block links to. A brand-new store
+    product has no public page: the id in its URL is only assigned at publish
+    time. A dead "Rate 5 stars" link is worse than no banner — especially inside
+    a package going through certification — and an unsubstituted
+    `__REVIEW_URL__` would ship the placeholder itself.
 
-    for f in cfg["firefox_only_files"]:
-        fp = os.path.join(dest, f)
-        if os.path.exists(fp):
-            os.remove(fp)
-
-    # --- Inject review URL + AF promo URL (GF only) ---
-    popup_path = os.path.join(dest, "popup.html")
-    if os.path.exists(popup_path):
-        with open(popup_path, "r", encoding="utf-8") as f:
-            html = f.read()
-        html = html.replace("__REVIEW_URL__", cfg["review_url_chrome"])
-        if "af_download_url_chrome" in cfg:
-            html = html.replace("__AF_DOWNLOAD_URL__", cfg["af_download_url_chrome"])
-            af_icon = os.path.join(ext_dir("ai-folders"), "icon48.png")
-            if os.path.exists(af_icon):
-                shutil.copy2(af_icon, os.path.join(dest, "af-icon.png"))
-        with open(popup_path, "w", encoding="utf-8") as f:
-            f.write(html)
-
-    mkt = marketing_dir(ext_name)
-    if mkt:
-        mkt_chrome = os.path.join(DIST_DIR, ext_name, "marketing_chrome")
-        shutil.copytree(mkt, mkt_chrome)
-        af_url = cfg.get("af_download_url_chrome", "")
-        if af_url:
-            for root_d, _, mkt_files in os.walk(mkt_chrome):
-                for fn in mkt_files:
-                    if not fn.endswith(".txt"):
-                        continue
-                    fp = os.path.join(root_d, fn)
-                    with open(fp, encoding="utf-8") as f:
-                        ct = f.read()
-                    if "__AF_STORE_URL__" in ct:
-                        with open(fp, "w", encoding="utf-8") as f:
-                            f.write(ct.replace("__AF_STORE_URL__", af_url))
-
-    zip_path = os.path.join(DIST_DIR, f"{cfg['zip_prefix']}-chrome-v{version}.zip")
-    make_zip(dest, zip_path)
-    print(f"✅ Chrome build: {zip_path}")
+    Closed by matching `<div>` depth rather than by a regex, so restyling the
+    block or changing its inner markup cannot silently cut the wrong thing.
+    Filling the URL back in restores the block on the next build.
+    """
+    start = html.find(f'<div id="{element_id}"')
+    if start == -1:
+        return html
+    depth, i = 0, start
+    while i < len(html):
+        nxt_open = html.find("<div", i)
+        nxt_close = html.find("</div>", i)
+        if nxt_close == -1:
+            return html                      # malformed: leave it alone
+        if nxt_open != -1 and nxt_open < nxt_close:
+            depth += 1
+            i = nxt_open + len("<div")
+        else:
+            depth -= 1
+            i = nxt_close + len("</div>")
+            if depth == 0:
+                return html[:start] + html[i:]
+    return html
 
 
-def build_firefox(ext_name, version):
-    cfg = EXTENSION_CONFIG[ext_name]
-    print(f"🦊 [{cfg['display_name']}] Building Firefox...")
+def apply_text_swaps(text, target, collapse=False):
+    """The per-target brand and shortcut substitutions. Returns (text, changed)."""
+    changed = False
+    for old, new in target["text_swaps"]:
+        if old in text:
+            text = text.replace(old, new)
+            changed = True
+    if collapse:
+        # On Firefox, Mac and PC share the shortcut, so any "(or Alt+Shift+S on
+        # Mac)" parenthetical is now redundant. Two shapes, depending on whether
+        # the first shortcut sits inside or outside the parens.
+        for pattern, repl in (
+            (r'(Alt\+Shift\+S)\s*[\(（][^)）]*Alt\+Shift\+S[^)）]*[\)）]', r'\1'),
+            (r'[\(（]Alt\+Shift\+S[^)）]*Alt\+Shift\+S[^)）]*[\)）]', r'(Alt+Shift+S)'),
+        ):
+            new_text = re.sub(pattern, repl, text)
+            if new_text != text:
+                text, changed = new_text, True
+    return text, changed
 
-    dest = os.path.join(DIST_DIR, ext_name, "firefox")
-    merge_into(SRC_DIR, ext_dir(ext_name), dest)
 
-    # --- 1. Patch manifest.json for Firefox ---
-    mfp = os.path.join(dest, "manifest.json")
-    with open(mfp, "r", encoding="utf-8") as f:
-        manifest = json.load(f)
-
+def patch_manifest_firefox(manifest, dest, cfg):
     manifest["browser_specific_settings"] = {
         "gecko": {
             "id": cfg["firefox_gecko_id"],
@@ -273,7 +327,7 @@ def build_firefox(ext_name, version):
         # the list can't silently drift from the importScripts(...) call.
         with open(os.path.join(dest, sw), "r", encoding="utf-8") as f:
             m = re.search(r"importScripts\(([^)]*)\)", f.read())
-        imports = [s.strip().strip("'\"") for s in m.group(1).split(",") if s.strip()] if m else []
+        imports = [x.strip().strip("'\"") for x in m.group(1).split(",") if x.strip()] if m else []
         manifest["background"]["scripts"] = imports + [sw]
 
     # Only patch the quick-save shortcut (Ctrl+Shift+S → Alt+Shift+S).
@@ -285,103 +339,131 @@ def build_firefox(ext_name, version):
                 if platform in qs["suggested_key"]:
                     qs["suggested_key"][platform] = "Alt+Shift+S"
 
-    with open(mfp, "w", encoding="utf-8") as f:
-        json.dump(manifest, f, indent=2, ensure_ascii=False)
 
-    # --- 2. Inject review URL + AF promo URL (GF only) ---
+MANIFEST_PATCHERS = {"firefox": patch_manifest_firefox}
+
+
+def inject_popup_urls(dest, cfg, target_name):
+    """Substitutes the store URLs, or removes the block that would link nowhere."""
     popup_path = os.path.join(dest, "popup.html")
-    if os.path.exists(popup_path):
-        with open(popup_path, "r", encoding="utf-8") as f:
-            html = f.read()
-        html = html.replace("__REVIEW_URL__", cfg["review_url_firefox"])
-        if "af_download_url_firefox" in cfg:
-            html = html.replace("__AF_DOWNLOAD_URL__", cfg["af_download_url_firefox"])
-            af_icon = os.path.join(ext_dir("ai-folders"), "icon48.png")
-            if os.path.exists(af_icon):
-                shutil.copy2(af_icon, os.path.join(dest, "af-icon.png"))
-        with open(popup_path, "w", encoding="utf-8") as f:
-            f.write(html)
+    if not os.path.exists(popup_path):
+        return
+    with open(popup_path, "r", encoding="utf-8") as f:
+        html = f.read()
 
-    # --- 4. Patch translations ---
+    review_url = cfg.get(f"review_url_{target_name}", "")
+    if review_url:
+        html = html.replace("__REVIEW_URL__", review_url)
+    else:
+        html = strip_block(html, "reviewBanner")
+
+    af_url = cfg.get(f"af_download_url_{target_name}", "")
+    if af_url:
+        html = html.replace("__AF_DOWNLOAD_URL__", af_url)
+        af_icon = os.path.join(ext_dir("ai-folders"), "icon48.png")
+        if os.path.exists(af_icon):
+            shutil.copy2(af_icon, os.path.join(dest, "af-icon.png"))
+    elif "__AF_DOWNLOAD_URL__" in html:
+        html = strip_block(html, "afPromoBanner")
+
+    with open(popup_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+
+def patch_locales(dest, target):
+    """Applies the target's text swaps to every translated string."""
+    if not target["text_swaps"]:
+        return
     locales_dir = os.path.join(dest, "_locales")
-    if os.path.exists(locales_dir):
-        for root, dirs, files in os.walk(locales_dir):
-            if "messages.json" not in files:
-                continue
-            msg_path = os.path.join(root, "messages.json")
-            with open(msg_path, "r", encoding="utf-8") as f:
-                messages = json.load(f)
+    if not os.path.exists(locales_dir):
+        return
+    for root, dirs, files in os.walk(locales_dir):
+        if "messages.json" not in files:
+            continue
+        msg_path = os.path.join(root, "messages.json")
+        with open(msg_path, "r", encoding="utf-8") as f:
+            messages = json.load(f)
 
-            modified = False
-            old_shortcuts = ["Ctrl+Shift+S", "Cmd+Shift+S", "Command+Shift+S", "⌘+Shift+S", "Strg+Shift+S"]
-            for val in messages.values():
-                if "message" not in val:
-                    continue
-                if "Chrome" in val["message"]:
-                    val["message"] = val["message"].replace("Chrome", "Firefox")
-                    modified = True
-                for sc in old_shortcuts:
-                    if sc in val["message"]:
-                        val["message"] = val["message"].replace(sc, "Alt+Shift+S")
-                        modified = True
+        modified = False
+        for val in messages.values():
+            if "message" not in val:
+                continue
+            # collapse=False: the "(or X on Mac)" cleanup is promo-text only.
+            val["message"], changed = apply_text_swaps(val["message"], target)
+            modified = modified or changed
+
+        if modified:
+            with open(msg_path, "w", encoding="utf-8") as f:
+                json.dump(messages, f, indent=2, ensure_ascii=False)
+
+
+def build_marketing(ext_name, cfg, target_name, target):
+    """Copies Marketing/<slug>/ to marketing_<target>/ and patches the promo texts."""
+    mkt = marketing_dir(ext_name)
+    if not mkt:
+        return
+    mkt_dest = os.path.join(DIST_DIR, ext_name, f"marketing_{target_name}")
+    shutil.copytree(mkt, mkt_dest)
+
+    af_url = cfg.get(f"af_download_url_{target_name}", "")
+    for root_dir, dirs, files in os.walk(mkt_dest):
+        for fn in files:
+            if not fn.endswith(".txt"):
+                continue
+            fp = os.path.join(root_dir, fn)
+            with open(fp, encoding="utf-8") as f:
+                content = f.read()
+
+            content, modified = apply_text_swaps(content, target,
+                                                 collapse=target["collapse_mac"])
+            if "__AF_STORE_URL__" in content:
+                if af_url:
+                    content = content.replace("__AF_STORE_URL__", af_url)
+                else:
+                    # No listing to point at on this store yet. Drop the line
+                    # rather than publish the placeholder — nothing here walks
+                    # marketing_*/ looking for unresolved placeholders, so this
+                    # would otherwise reach the store as literal text.
+                    content = "\n".join(ln for ln in content.split("\n")
+                                        if "__AF_STORE_URL__" not in ln)
+                modified = True
 
             if modified:
-                with open(msg_path, "w", encoding="utf-8") as f:
-                    json.dump(messages, f, indent=2, ensure_ascii=False)
+                with open(fp, "w", encoding="utf-8") as f:
+                    f.write(content)
 
-    # --- 5. Patch marketing text files ---
-    mkt = marketing_dir(ext_name)
-    if mkt:
-        print(f"📸 Processing marketing assets for Firefox...")
-        mkt_dest = os.path.join(DIST_DIR, ext_name, "marketing_firefox")
-        shutil.copytree(mkt, mkt_dest)
 
-        old_shortcuts = ["Ctrl+Shift+S", "Cmd+Shift+S", "Command+Shift+S", "⌘+Shift+S", "Strg+Shift+S"]
-        for root_dir, dirs, files in os.walk(mkt_dest):
-            for file in files:
-                if not file.endswith(".txt"):
-                    continue
-                fp = os.path.join(root_dir, file)
-                with open(fp, "r", encoding="utf-8") as f:
-                    content = f.read()
+def build_target(ext_name, version, target_name):
+    """Builds one store target. Every per-target difference is data in TARGETS."""
+    cfg = EXTENSION_CONFIG[ext_name]
+    target = TARGETS[target_name]
+    print(f"{target['emoji']} [{cfg['display_name']}] Building {target['label']}...")
 
-                modified = False
-                if "Chrome" in content:
-                    content = content.replace("Chrome", "Firefox")
-                    modified = True
-                for sc in old_shortcuts:
-                    if sc in content:
-                        content = content.replace(sc, "Alt+Shift+S")
-                        modified = True
-                # On Firefox, Mac and PC share the same shortcut, so any
-                # "(or Alt+Shift+S on Mac)" parenthetical is now redundant.
-                # Case 1: shortcut outside parens — "Alt+Shift+S (or Alt+Shift+S on Mac)"
-                new_content = re.sub(
-                    r'(Alt\+Shift\+S)\s*[\(（][^)）]*Alt\+Shift\+S[^)）]*[\)）]',
-                    r'\1', content
-                )
-                if new_content != content:
-                    content, modified = new_content, True
-                # Case 2: both shortcuts inside parens — "(Alt+Shift+S or Alt+Shift+S on Mac)"
-                new_content = re.sub(
-                    r'[\(（]Alt\+Shift\+S[^)）]*Alt\+Shift\+S[^)）]*[\)）]',
-                    r'(Alt+Shift+S)', content
-                )
-                if new_content != content:
-                    content, modified = new_content, True
+    dest = os.path.join(DIST_DIR, ext_name, target_name)
+    merge_into(SRC_DIR, ext_dir(ext_name), dest)
 
-                af_url = cfg.get("af_download_url_firefox", "")
-                if af_url and "__AF_STORE_URL__" in content:
-                    content = content.replace("__AF_STORE_URL__", af_url)
-                    modified = True
+    if target["drop_files"]:
+        for f in cfg.get(target["drop_files"], []):
+            fp = os.path.join(dest, f)
+            if os.path.exists(fp):
+                os.remove(fp)
 
-                if modified:
-                    with open(fp, "w", encoding="utf-8") as f:
-                        f.write(content)
+    patcher = MANIFEST_PATCHERS.get(target["patch_manifest"])
+    if patcher:
+        mfp = os.path.join(dest, "manifest.json")
+        with open(mfp, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+        patcher(manifest, dest, cfg)
+        with open(mfp, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, ensure_ascii=False)
 
-    zip_path = os.path.join(DIST_DIR, f"{cfg['zip_prefix']}-firefox-v{version}.zip")
+    inject_popup_urls(dest, cfg, target_name)
+    patch_locales(dest, target)
+    build_marketing(ext_name, cfg, target_name, target)
+
+    zip_path = os.path.join(DIST_DIR, f"{cfg['zip_prefix']}-{target_name}-v{version}.zip")
     make_zip(dest, zip_path)
-    print(f"✅ Firefox build: {zip_path}")
+    print(f"✅ {target['label']} build: {zip_path}")
 
 
 def build_extension(ext_name):
@@ -394,8 +476,8 @@ def build_extension(ext_name):
         version = json.load(f).get("version", "unknown")
 
     print(f"\n📦 {EXTENSION_CONFIG[ext_name]['display_name']} v{version}")
-    build_chrome(ext_name, version)
-    build_firefox(ext_name, version)
+    for target_name in TARGETS:
+        build_target(ext_name, version, target_name)
 
 
 # ---------------------------------------------------------------------------

--- a/extensions/ai-folders/background.js
+++ b/extensions/ai-folders/background.js
@@ -153,6 +153,23 @@ async function updateContextMenu() {
 // Page: docs/uninstall-ai-folders.html. Helper: buildUninstallUrl (utils.js).
 const UNINSTALL_SURVEY_URL = 'https://aifolders.xyz/uninstall-ai-folders.html';
 
+// Which browser this copy is running in, for the uninstall survey's `b=` param.
+//
+// Edge's user agent carries BOTH "Edg/" and "Chrome/", so Edge has to be tested
+// first — otherwise every Edge uninstall reports as Chrome, which is exactly the
+// distinction this field exists to make. Matching "Edg" rather than "Edge"
+// covers EdgA/ on Android and EdgiOS/ as well.
+//
+// Adding a value here is only half the job: the survey posts it to a Google
+// Form, and a Form field that is multiple-choice silently drops an option it
+// does not know (see CLAUDE.md §9 — the Form is the schema).
+function detectBrowser() {
+  const ua = navigator.userAgent;
+  if (/Firefox/.test(ua)) return 'firefox';
+  if (/Edg/.test(ua)) return 'edge';
+  return 'chrome';
+}
+
 // setUninstallURL captures the value at call time and the page may be opened
 // months later, so the URL is re-signed whenever the numbers it carries move.
 async function refreshUninstallUrl() {
@@ -166,7 +183,7 @@ async function refreshUninstallUrl() {
       saves: (usageStats || {}).saves,
       version: chrome.runtime.getManifest().version,
       lang: chrome.i18n.getUILanguage(),
-      browser: /Firefox/.test(navigator.userAgent) ? 'firefox' : 'chrome',
+      browser: detectBrowser(),
     }));
   } catch (_) { /* best-effort: never break the worker over the survey */ }
 }

--- a/extensions/gemini-folders/background.js
+++ b/extensions/gemini-folders/background.js
@@ -71,6 +71,23 @@ function updateContextMenu() {
 // Page: docs/uninstall-gemini-folders.html. Helper: buildUninstallUrl (utils.js).
 const UNINSTALL_SURVEY_URL = 'https://aifolders.xyz/uninstall-gemini-folders.html';
 
+// Which browser this copy is running in, for the uninstall survey's `b=` param.
+//
+// Edge's user agent carries BOTH "Edg/" and "Chrome/", so Edge has to be tested
+// first — otherwise every Edge uninstall reports as Chrome, which is exactly the
+// distinction this field exists to make. Matching "Edg" rather than "Edge"
+// covers EdgA/ on Android and EdgiOS/ as well.
+//
+// Adding a value here is only half the job: the survey posts it to a Google
+// Form, and a Form field that is multiple-choice silently drops an option it
+// does not know (see CLAUDE.md §9 — the Form is the schema).
+function detectBrowser() {
+  const ua = navigator.userAgent;
+  if (/Firefox/.test(ua)) return 'firefox';
+  if (/Edg/.test(ua)) return 'edge';
+  return 'chrome';
+}
+
 // setUninstallURL captures the value at call time and the page may be opened
 // months later, so the URL is re-signed whenever the numbers it carries move.
 async function refreshUninstallUrl() {
@@ -84,7 +101,7 @@ async function refreshUninstallUrl() {
       saves: (usageStats || {}).saves,
       version: chrome.runtime.getManifest().version,
       lang: chrome.i18n.getUILanguage(),
-      browser: /Firefox/.test(navigator.userAgent) ? 'firefox' : 'chrome',
+      browser: detectBrowser(),
     }));
   } catch (_) { /* best-effort: never break the worker over the survey */ }
 }

--- a/store-publisher.config.json
+++ b/store-publisher.config.json
@@ -26,6 +26,16 @@
         "key": "version"
       }
     },
+    "edge": {
+      "description": "dist/{slug}/marketing_edge/Promo{LANG}.txt",
+      "screenshot": "dist/{slug}/marketing_edge/screenshots/Promo_{n}_{lang}.png",
+      "screenshotsPerListing": 5,
+      "package": "dist/{slug}-edge-v{version}.zip",
+      "versionSource": {
+        "path": "dist/{slug}/edge/manifest.json",
+        "key": "version"
+      }
+    },
     "firefox": {
       "description": "dist/{slug}/marketing_firefox/Promo{LANG}.txt",
       "screenshot": "dist/{slug}/marketing_firefox/screenshots/Promo_{n}_{lang}.png",

--- a/tests/store-publisher-config.test.js
+++ b/tests/store-publisher-config.test.js
@@ -70,8 +70,18 @@ describe('store-publisher.config.json', () => {
     expect(overrides).toEqual(['zh_CN']);
   });
 
+  // Every store this project publishes to. Kept in one place because the loops
+  // below all walk it, and because the build.py binding asserts build.py's own
+  // target table matches it exactly.
+  const STORES = ['chrome', 'edge', 'firefox'];
+
+  test('a profile exists for every store, and no store is left undeclared', () => {
+    expect(Object.keys(config.assets).sort()).toEqual([...STORES].sort());
+  });
+
   test('the path templates point at dist/, which build.py produces', () => {
-    for (const [store, dir] of [['chrome', 'marketing_chrome'], ['firefox', 'marketing_firefox']]) {
+    for (const store of STORES) {
+      const dir = `marketing_${store}`;
       const profile = config.assets[store];
       expect(profile.description).toBe(`dist/{slug}/${dir}/Promo{LANG}.txt`);
       expect(profile.screenshot).toBe(`dist/{slug}/${dir}/screenshots/Promo_{n}_{lang}.png`);
@@ -84,7 +94,7 @@ describe('store-publisher.config.json', () => {
   // manifest, which is what stops the version in the filename from disagreeing
   // with the bytes inside it.
   test('the package templates match what build.py emits', () => {
-    for (const store of ['chrome', 'firefox']) {
+    for (const store of STORES) {
       const profile = config.assets[store];
       expect(profile.package).toBe(`dist/{slug}-${store}-v{version}.zip`);
       expect(profile.versionSource).toEqual({
@@ -96,31 +106,49 @@ describe('store-publisher.config.json', () => {
   // Not a style check: a template that lost {version} or {slug} would resolve to
   // one path for every item and release, and upload whichever build was there.
   test('every package template keeps the placeholders that make it specific', () => {
-    for (const store of ['chrome', 'firefox']) {
+    for (const store of STORES) {
       expect(config.assets[store].package).toContain('{slug}');
       expect(config.assets[store].package).toContain('{version}');
       expect(config.assets[store].versionSource.path).toContain('{slug}');
     }
   });
 
-  // The string comparison above only says the config still says what it said.
-  // This binds it to the code that actually names the files: rename the zip in
+  // The comparisons above only say the config still says what it said. These
+  // bind it to the code that actually names the files: rename the zip in
   // build.py and the publisher would look for a file that is never written.
+  //
+  // This used to assert the literal `-chrome-` and `-firefox-` substrings and
+  // the exact indentation of zip_prefix. That worked while build.py had one
+  // hand-written function per target; generalizing it to a TARGETS table made
+  // those strings disappear, so the assertions were re-aimed at the general
+  // form. Same intention, mechanism that survives a third store.
   describe('bound to what build.py actually emits', () => {
     const buildPy = fs.readFileSync(path.join(ROOT, 'build.py'), 'utf8');
 
-    test('build.py still names the zips <prefix>-<browser>-v<version>.zip', () => {
-      for (const store of ['chrome', 'firefox']) {
-        expect(buildPy).toContain(
-          `f"{cfg['zip_prefix']}-${store}-v{version}.zip"`);
-      }
+    // The single f-string every target's archive is named by.
+    test('build.py names the zips <prefix>-<target>-v<version>.zip', () => {
+      expect(buildPy).toContain(
+        `f"{cfg['zip_prefix']}-{target_name}-v{version}.zip"`);
+    });
+
+    // The store profiles above are only meaningful if build.py actually builds
+    // those targets — a profile for a target build.py never emits would resolve
+    // to paths nothing writes.
+    test('build.py\'s TARGETS table is exactly the stores in the config', () => {
+      const table = buildPy.slice(buildPy.indexOf('TARGETS = {'));
+      const declared = [...table.slice(0, table.indexOf('\n}'))
+        .matchAll(/^ {4}"(\w+)": \{$/gm)].map(m => m[1]);
+      expect(declared.sort()).toEqual([...STORES].sort());
     });
 
     // The templates use {slug}; build.py uses zip_prefix. They are only
     // interchangeable while those two strings agree, for every item.
-    test('each item’s slug is its zip_prefix in build.py', () => {
+    // Whitespace-tolerant: the old form pinned the exact column, which made
+    // re-indenting EXTENSION_CONFIG a test failure for no reason.
+    test('each item\'s slug is its zip_prefix in build.py', () => {
       for (const item of config.items) {
-        expect(buildPy).toContain(`"zip_prefix":         "${item.slug}"`);
+        expect(buildPy).toMatch(
+          new RegExp(`"zip_prefix":\\s*"${item.slug}"`));
       }
     });
   });

--- a/tests/uninstall-browser.test.js
+++ b/tests/uninstall-browser.test.js
@@ -1,0 +1,116 @@
+// Which browser the uninstall survey reports.
+//
+// The `b=` param is what separates a Chrome uninstall from a Firefox one in the
+// survey data, and now from an Edge one. Edge is the case worth a test: its user
+// agent contains BOTH "Edg/" and "Chrome/", so a naive check reports every Edge
+// uninstall as Chrome — silently, and in a way that only shows up as a slow
+// contamination of the numbers CLAUDE.md §11 draws conclusions from.
+//
+// This runs the real onInstalled listener and reads the URL actually handed to
+// chrome.runtime.setUninstallURL, rather than testing the helper in isolation:
+// the helper is not exported, and what matters is what the browser receives.
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const EXTENSIONS = ['ai-folders', 'gemini-folders'];
+
+// Real user agents, kept verbatim — the whole point is the overlap between them.
+const AGENTS = {
+  chrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+  edgeAndroid: 'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EdgA/120.0.0.0',
+  firefox: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:142.0) Gecko/20100101 Firefox/142.0',
+};
+
+const manifestVersion = (ext) => JSON.parse(fs.readFileSync(
+  path.join(ROOT, 'extensions', ext, 'manifest.json'), 'utf8')).version;
+
+function setUserAgent(ua) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua, configurable: true,
+  });
+}
+
+// Loads a service worker the way the browser does — the top level only registers
+// listeners — then fires onInstalled and returns the uninstall URL it set.
+async function uninstallUrlFor(ext, ua) {
+  jest.resetModules();
+  setUserAgent(ua);
+
+  const local = {};
+  let onInstalled = null;
+  const noop = { addListener: () => {} };
+
+  chrome.runtime.onInstalled = { addListener: (fn) => { onInstalled = fn; } };
+  chrome.runtime.onStartup = noop;
+  chrome.runtime.onMessage = noop;
+  chrome.runtime.getManifest = jest.fn(() => ({ version: manifestVersion(ext) }));
+  chrome.runtime.setUninstallURL = jest.fn(async () => {});
+  chrome.i18n.getUILanguage = jest.fn(() => 'en-US');
+  chrome.storage.onChanged = noop;
+  chrome.storage.local.get = jest.fn(async (keys) =>
+    Object.fromEntries([].concat(keys).filter(k => k in local).map(k => [k, local[k]])));
+  chrome.storage.local.set = jest.fn(async (obj) => { Object.assign(local, obj); });
+  chrome.storage.sync.get = jest.fn(async () => ({}));
+  chrome.contextMenus = { removeAll: jest.fn(), create: jest.fn(), onClicked: noop };
+  chrome.commands = { onCommand: noop };
+  chrome.permissions = { onAdded: noop, contains: jest.fn((_p, cb) => cb && cb(false)) };
+  chrome.scripting = {
+    registerContentScripts: jest.fn(async () => {}),
+    unregisterContentScripts: jest.fn(async () => {}),
+  };
+  chrome.tabs.create = jest.fn();
+
+  // The real service worker pulls these in with importScripts, so they are
+  // plain globals there. Without them refreshUninstallUrl throws a
+  // ReferenceError straight into its own best-effort catch, and the failure
+  // looks exactly like "the browser was never told" — which is what this test
+  // measures, so it would pass or fail for the wrong reason.
+  global.buildUninstallUrl = require('../src/utils').buildUninstallUrl;
+
+  require(`../extensions/${ext}/background.js`);
+  expect(onInstalled).not.toBeNull();
+  await onInstalled({ reason: 'install' });
+  // refreshUninstallUrl is fired without await inside the listener.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const calls = chrome.runtime.setUninstallURL.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1][0];
+}
+
+// The context rides in the fragment, never the query — see CLAUDE.md §9.
+const browserParam = (url) =>
+  new URLSearchParams(new URL(url).hash.slice(1)).get('b');
+
+describe.each(EXTENSIONS)('%s uninstall survey', (ext) => {
+  test('Chrome reports chrome', async () => {
+    expect(browserParam(await uninstallUrlFor(ext, AGENTS.chrome))).toBe('chrome');
+  });
+
+  test('Firefox reports firefox', async () => {
+    expect(browserParam(await uninstallUrlFor(ext, AGENTS.firefox))).toBe('firefox');
+  });
+
+  // The regression this file exists for. Edge's UA says "Chrome/120" too, so
+  // testing Chrome first would swallow every Edge install into the Chrome bucket.
+  test('Edge reports edge, not chrome', async () => {
+    const value = browserParam(await uninstallUrlFor(ext, AGENTS.edge));
+    expect(value).toBe('edge');
+    expect(value).not.toBe('chrome');
+  });
+
+  test('Edge on Android reports edge as well', async () => {
+    expect(browserParam(await uninstallUrlFor(ext, AGENTS.edgeAndroid))).toBe('edge');
+  });
+
+  // Three buckets and nothing else: an unrecognised agent must land somewhere
+  // known rather than send an empty or invented value to the Form.
+  test('every agent lands in one of the three known values', async () => {
+    for (const ua of Object.values(AGENTS)) {
+      expect(['chrome', 'edge', 'firefox'])
+        .toContain(browserParam(await uninstallUrlFor(ext, ua)));
+    }
+  });
+});

--- a/tools/validate_build.py
+++ b/tools/validate_build.py
@@ -20,7 +20,7 @@ import zipfile
 
 DIST = "dist"
 EXTENSIONS = ["ai-folders", "gemini-folders"]
-BROWSERS = ["chrome", "firefox"]
+BROWSERS = ["chrome", "edge", "firefox"]
 EXPECTED_LOCALES = 43
 
 failures = []
@@ -105,6 +105,28 @@ def check_placeholders(ext, browser):
                 fail(f"{ext}/{browser}/{os.path.relpath(path, root)}: unresolved {hit}")
 
 
+def check_marketing_placeholders(ext, browser):
+    """The promo texts ship as store copy, so a placeholder left in one is read
+    by users, not by a parser. Checked separately from the extension tree
+    because it lives beside it, in marketing_<browser>/."""
+    root = os.path.join(DIST, ext, f"marketing_{browser}")
+    if not os.path.isdir(root):
+        return
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            if not name.endswith(".txt"):
+                continue
+            path = os.path.join(dirpath, name)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    content = f.read()
+            except (UnicodeDecodeError, OSError):
+                continue
+            for hit in set(PLACEHOLDER.findall(content)):
+                fail(f"{ext}/marketing_{browser}/{os.path.relpath(path, root)}: "
+                     f"unresolved {hit}")
+
+
 def check_zip(ext, version):
     """The shipped archive must carry the extension and nothing else."""
     for browser in BROWSERS:
@@ -136,6 +158,7 @@ def main():
                 version = built.get("version")
             check_locales(ext, browser)
             check_placeholders(ext, browser)
+            check_marketing_placeholders(ext, browser)
         if version:
             check_zip(ext, version)
 
@@ -152,7 +175,8 @@ def main():
             print(f"   - {f}")
         return 1
 
-    print("✅ Build artifacts validated: manifests, permissions, locales, placeholders, archives.")
+    print(f"✅ Build artifacts validated for {len(BROWSERS)} targets: "
+          f"manifests, permissions, locales, placeholders, promo texts, archives.")
     return 0
 
 


### PR DESCRIPTION
`build.py` had **no target abstraction**: `build_chrome` and `build_firefox` were two ~90%-identical functions, and every per-target value was a config key with the browser baked into its name. Copying one for Edge would have made a third copy of the same 90 lines, so the two collapse into `build_target()` driven by a `TARGETS` table. Adding a fourth store is now a row.

Edge is Chromium, so it keeps `Ctrl+Shift+S` (same `commands` API) and gets no gecko id. Its one substitution is `Chrome` → `Microsoft Edge`, which certification requires: *"If Chrome is used in either the name or the description of your extension, rebrand the extension using Microsoft Edge."* A brand swap is language-independent, exactly like the Firefox one.

## The store URLs that do not exist yet

A listing's public URL carries an id Partner Center only assigns at publish — and the package must be uploaded **before** the listing can be filled. So `review_url_<target>` and `af_download_url_<target>` are allowed to be empty, and the build then **removes** the block that would link nowhere, rather than ship a dead "Rate 5 stars" link or an unsubstituted `__REVIEW_URL__` through certification. Same for the promo line carrying `__AF_STORE_URL__`.

Both come back by themselves once the URLs are filled in — nothing to remember later. `strip_block` closes on matching `<div>` depth rather than a regex, so restyling the banner cannot silently cut the wrong thing.

That exposed a real gap: **`validate_build.py` never walked `marketing_*/`**. Survivable while every promo placeholder was always substituted, but a promo file is store copy — a placeholder left in one is read by users, not by a parser. Checked now.

## A bug fixed before it could cost anything

Both `background.js` reported Edge as `chrome` in the uninstall survey, because Edge's user agent contains `Chrome/` too. Every Edge uninstall would have landed in the Chrome bucket, silently contaminating the numbers §11 draws conclusions from.

Three-way detection now, in both copies (§6), Edge tested first. `tests/uninstall-browser.test.js` runs the real `onInstalled` listener and reads the URL actually handed to the browser — checked against the old ternary restored on purpose, where it fails on exactly the two Edge cases.

⚠️ **Before any Edge user exists**, check that the `browser` field in both Google Forms accepts `edge`. Per §9 the Form is the schema: a multiple-choice field silently drops an unknown option. No urgency — Edge is not published yet, so the fix lands ahead of the first install.

## The binding test blocked this refactor, as predicted

The test I added last PR asserted the literal `-chrome-` / `-firefox-` substrings in `build.py`'s source and the exact indentation of `zip_prefix` — both disappear when the target is parameterized. Its intention was right, its mechanism was not.

It now asserts the general form **and** that `build.py`'s `TARGETS` table matches the config's store profiles exactly — a profile for a target nothing builds would resolve to paths nothing writes. Verified in both directions.

## Verification

- `npx jest` — 822 passing (24 suites).
- `python build.py --yes` emits six zips; `validate_build.py` clean over 3 targets.
- **Directed diff** of the Edge tree against Chrome: exactly one locale key differs (`syncBookmarksTooltip`, 43/43) plus `popup.html`. No "Chrome" left in the Edge locales or the Edge promo texts.
- Firefox regression check: gecko id, min version, background scripts parsed from `importScripts`, `Alt+Shift+S`, `import.html` present — all unchanged.

Known and deliberate: the Edge tooltip currently reads "Microsoft Edge bookmarks", where Edge's own term is **Favorites**. That is the next commit, and it is per-language — French already says "favoris".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
