### PR TITLE
fix(build): fit the Edge listing description inside Microsoft's 10,000-char cap

### DIFF
--- a/build.py
+++ b/build.py
@@ -53,6 +53,13 @@ EXTENSION_CONFIG = {
     },
 }
 
+# A line that is a version-history entry. Used to decide what may be dropped
+# when a store caps the description length: the history sits at the tail of every
+# promo text, oldest last, so trimming from the end costs the least. The word
+# itself is translated ("Bersyon" in Filipino), which is why this matches the
+# NUMBER instead — the one part that stays put in all 43 languages.
+HISTORY_LINE = re.compile(r"\d+\.\d")
+
 # Messages that exist only to be swapped in for some target. They are never
 # shipped under their own name — patch_locales drops them from every build.
 BUILD_ONLY_MESSAGES = ["syncFavoritesTooltip"]
@@ -81,6 +88,7 @@ TARGETS = {
         "drop_files": "firefox_only_files",
         "text_swaps": [],
         "message_aliases": {},
+        "description_max": None,
         "collapse_mac": False,
         "patch_manifest": None,
     },
@@ -94,6 +102,11 @@ TARGETS = {
         # required." A brand swap is language-independent, exactly like Firefox's.
         # The quick-save shortcut is NOT swapped: Edge shares Chrome's commands API.
         "text_swaps": [("Chrome", "Microsoft Edge")],
+        # Microsoft caps a store-listing description at 10,000 characters, and
+        # 15 of the 86 promo texts are over it — French by 755. Discovered before
+        # writing the listing driver rather than as a form error in the middle of
+        # a 43-language run.
+        "description_max": 10000,
         # Edge calls them Favorites, not bookmarks, and chrome.bookmarks really
         # does manipulate Favorites there — so the tooltip was wrong twice over.
         # The replacement runs BEFORE the brand swap, which is why the stored
@@ -112,6 +125,7 @@ TARGETS = {
         "text_swaps": ([("Chrome", "Firefox")]
                        + [(sc, "Alt+Shift+S") for sc in QUICK_SAVE_SPELLINGS]),
         "message_aliases": {},
+        "description_max": None,
         "collapse_mac": True,
         "patch_manifest": "firefox",
     },
@@ -426,6 +440,38 @@ def patch_locales(dest, target):
                 json.dump(messages, f, indent=2, ensure_ascii=False)
 
 
+def trim_description(text, limit, where):
+    """Drops version-history lines from the end until the text fits `limit`.
+
+    Stores cap the listing description, and the promo texts run past Edge's cap
+    in 15 of 86 files. Trimming from the tail is what costs least: the history is
+    the last block and its oldest entries are the least useful.
+
+    It refuses rather than truncates. If the line it is about to drop is not a
+    history entry, the text has run out of history and the next thing to go would
+    be a feature — so it stops and says so, instead of quietly publishing a
+    listing with its last paragraph missing.
+    """
+    if not limit or len(text) <= limit:
+        return text, 0
+
+    lines = text.split("\n")
+    dropped = 0
+    while len("\n".join(lines)) > limit:
+        while lines and not lines[-1].strip():
+            lines.pop()
+        if not lines:
+            sys.exit(f"{where}: nothing left to trim.")
+        if not HISTORY_LINE.search(lines[-1]):
+            sys.exit(f"{where}: {len(text)} chars, limit {limit}, and the next line "
+                     f"to drop is not version history:\n    {lines[-1][:120]}\n"
+                     f"Shorten the promo text itself rather than letting the build "
+                     f"eat a feature paragraph.")
+        lines.pop()
+        dropped += 1
+    return "\n".join(lines).rstrip() + "\n", dropped
+
+
 def build_marketing(ext_name, cfg, target_name, target):
     """Copies Marketing/<slug>/ to marketing_<target>/ and patches the promo texts."""
     mkt = marketing_dir(ext_name)
@@ -435,6 +481,7 @@ def build_marketing(ext_name, cfg, target_name, target):
     shutil.copytree(mkt, mkt_dest)
 
     af_url = cfg.get(f"af_download_url_{target_name}", "")
+    trimmed = []
     for root_dir, dirs, files in os.walk(mkt_dest):
         for fn in files:
             if not fn.endswith(".txt"):
@@ -457,9 +504,23 @@ def build_marketing(ext_name, cfg, target_name, target):
                                         if "__AF_STORE_URL__" not in ln)
                 modified = True
 
+            # Only the listing descriptions are capped; the screenshots dir and
+            # any other .txt beside them are not descriptions.
+            if fn.lower().startswith("promo"):
+                content, dropped = trim_description(
+                    content, target.get("description_max"),
+                    f"{ext_name}/{target_name}/{fn}")
+                if dropped:
+                    trimmed.append(f"{fn}(-{dropped})")
+                    modified = True
+
             if modified:
                 with open(fp, "w", encoding="utf-8") as f:
                     f.write(content)
+
+    if trimmed:
+        print(f"   trimmed to {target['description_max']} chars: "
+              f"{len(trimmed)} file(s) — {', '.join(sorted(trimmed))}")
 
 
 def build_target(ext_name, version, target_name):

--- a/tests/edge-description-limit.test.js
+++ b/tests/edge-description-limit.test.js
@@ -1,0 +1,101 @@
+// Microsoft caps a store-listing description at 10,000 characters.
+//
+// 15 of the 86 promo texts are naturally over it — French by 755 — so build.py
+// trims version-history lines off the tail for the Edge target only. The history
+// sits last and its oldest entries are the least useful, so that is the cheapest
+// thing to lose; Chrome (16,000) and AMO have room and are left alone.
+//
+// This test guards the SOURCE, not the build: it asks whether each promo text can
+// still reach the cap by dropping only history. If someone adds three paragraphs
+// of features to a long locale, the answer becomes no — and that should surface
+// here, in the test job, rather than as a build failure or, worse, as a listing
+// with its last section missing. tools/validate_build.py checks the built output.
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const EXTENSIONS = ['ai-folders', 'gemini-folders'];
+const EDGE_MAX = 10000;
+
+// A version-history line. The word is translated — Filipino says "Bersyon" — so
+// this matches the number, the one part that stays put across all 43 languages.
+const HISTORY_LINE = /\d+\.\d/;
+
+const promoFiles = (ext) => {
+  const dir = path.join(ROOT, 'Marketing', ext);
+  return fs.readdirSync(dir)
+    .filter((f) => /^Promo.*\.txt$/.test(f))
+    .map((f) => [f, fs.readFileSync(path.join(dir, f), 'utf8')]);
+};
+
+// Mirrors build.py's trim_description: drop trailing history lines until it
+// fits, and refuse the moment the next line is not history.
+function trimmable(text, limit) {
+  let lines = text.split('\n');
+  let dropped = 0;
+  const joined = () => lines.join('\n');
+  while (joined().length > limit) {
+    while (lines.length && !lines[lines.length - 1].trim()) lines.pop();
+    if (!lines.length) return { ok: false, dropped, blocker: '(empty)' };
+    const last = lines[lines.length - 1];
+    if (!HISTORY_LINE.test(last)) {
+      return { ok: false, dropped, blocker: last.slice(0, 70) };
+    }
+    lines.pop();
+    dropped += 1;
+  }
+  return { ok: true, dropped };
+}
+
+describe.each(EXTENSIONS)('%s promo texts fit the Edge cap', (ext) => {
+  const files = promoFiles(ext);
+
+  test('there are 43 of them', () => {
+    expect(files).toHaveLength(43);
+  });
+
+  test('every one reaches the cap by dropping only version history', () => {
+    const blocked = files
+      .map(([name, text]) => [name, trimmable(text, EDGE_MAX)])
+      .filter(([, r]) => !r.ok)
+      .map(([name, r]) => `${name}: ran out of history at "${r.blocker}"`);
+    expect(blocked).toEqual([]);
+  });
+
+  // Headroom, not just feasibility. Trimming the whole history away to fit would
+  // technically pass the test above while leaving a listing with no changelog at
+  // all — and would mean the next feature paragraph breaks the build.
+  test('no locale has to give up more than half its history', () => {
+    const greedy = files
+      .map(([name, text]) => {
+        const history = text.split('\n').filter((l) => HISTORY_LINE.test(l)).length;
+        const { dropped } = trimmable(text, EDGE_MAX);
+        return [name, dropped, history];
+      })
+      .filter(([, dropped, history]) => history > 0 && dropped > history / 2)
+      .map(([name, dropped, history]) => `${name}: ${dropped} of ${history} entries`);
+    expect(greedy).toEqual([]);
+  });
+
+  // The ones that need trimming at all are worth naming: if this set grows a lot,
+  // the promo texts are drifting long and the cap is the wrong thing to fix.
+  test('the set that needs trimming stays small', () => {
+    const trimmed = files.filter(([, text]) => text.length > EDGE_MAX);
+    expect(trimmed.length).toBeLessThan(15);
+  });
+});
+
+describe('build.py owns the cap', () => {
+  const buildPy = fs.readFileSync(path.join(ROOT, 'build.py'), 'utf8');
+
+  test('the Edge target declares it, and the other two do not', () => {
+    expect(buildPy).toContain('"description_max": 10000,');
+    // Two targets with no cap: Chrome's is far higher and AMO has room.
+    expect(buildPy.match(/"description_max": None,/g)).toHaveLength(2);
+  });
+
+  test('the trim refuses rather than truncating', () => {
+    expect(buildPy).toContain('if not HISTORY_LINE.search(lines[-1]):');
+    expect(buildPy).toMatch(/Shorten the promo text itself/);
+  });
+});

--- a/tools/validate_build.py
+++ b/tools/validate_build.py
@@ -22,6 +22,12 @@ DIST = "dist"
 EXTENSIONS = ["ai-folders", "gemini-folders"]
 BROWSERS = ["chrome", "edge", "firefox"]
 EXPECTED_LOCALES = 43
+# Per-store cap on the listing description. Microsoft rejects anything over
+# 10,000 characters, and 15 of the 86 promo texts are naturally over it, so
+# build.py trims version-history lines off the tail for that target. This is the
+# check that the trim actually happened — a rejection here is cheap, a rejection
+# from Partner Center comes after a submission.
+DESCRIPTION_MAX = {"edge": 10000}
 
 failures = []
 
@@ -125,6 +131,10 @@ def check_marketing_placeholders(ext, browser):
             for hit in set(PLACEHOLDER.findall(content)):
                 fail(f"{ext}/marketing_{browser}/{os.path.relpath(path, root)}: "
                      f"unresolved {hit}")
+            limit = DESCRIPTION_MAX.get(browser)
+            if limit and name.lower().startswith("promo") and len(content) > limit:
+                fail(f"{ext}/marketing_{browser}/{name}: {len(content)} chars, "
+                     f"over the {limit} the store accepts")
 
 
 def check_zip(ext, version):
@@ -175,8 +185,8 @@ def main():
             print(f"   - {f}")
         return 1
 
-    print(f"✅ Build artifacts validated for {len(BROWSERS)} targets: "
-          f"manifests, permissions, locales, placeholders, promo texts, archives.")
+    print(f"✅ Build artifacts validated for {len(BROWSERS)} targets: manifests, "
+          f"permissions, locales, placeholders, promo texts and their length, archives.")
     return 0
 
 


### PR DESCRIPTION
Reading Partner Center's own docs *before* writing the listing driver turned up a blocker.

**Microsoft caps a store-listing description at 10,000 characters, and 15 of the 86 promo texts are over it** — French by 755. Left alone that would have surfaced as a form error somewhere in the middle of a 43-language run, after a submission, in a language nobody here reads.

| | max before | max after |
|---|---|---|
| Edge | 10,755 / 10,707 | **9,983 / 9,927** |
| Chrome | 10,731 / 10,785 | unchanged |
| Firefox | 10,684 / 10,707 | unchanged |

## What gets cut, and why it is the right thing

The promo texts end with a version history, newest first, so the tail is both the easiest place to cut and the least valuable. For the **Edge target only**, `build.py` drops history lines off the end until the text fits — 7 files for AI Folders, 8 for Gemini Folders, one to three lines each. French loses its 1.2, 1.1 and 1.0 entries.

Chrome (16,000) and AMO have room and are untouched.

## Two things that make it a trim rather than a truncation

**It keys on the version number, not the word.** Filipino says *"Bersyon"* — a regex for "Version" would have matched nothing there and either trimmed the wrong lines or nothing at all, failing at the store instead.

**It refuses when the history runs out.** If the next line to drop is not a history entry, the build stops and prints it, because what follows the history is a feature paragraph. Checked by setting the cap to 4,000:

```
test/FR: 10731 chars, limit 4000, and the next line to drop is not version history:
    📢 MISES À JOUR :
Shorten the promo text itself rather than letting the build eat a feature paragraph.
```

## Guarded at both ends

- `tests/edge-description-limit.test.js` checks the **source**: can each text still reach the cap by dropping only history, does any locale give up more than half of it, and does the set needing a trim stay small. Add three paragraphs to a long locale and this fails in the *test* job — not at build time, and not at submission time.
- `tools/validate_build.py` checks the **built output**, and was verified against a deliberate 400-character overage:
  `ai-folders/marketing_edge/PromoFR.txt: 10314 chars, over the 10000 the store accepts`

## Verification

- `npx jest` — 855 passing (27 suites).
- `build.py` + `validate_build.py` clean over 3 targets; tree unchanged after a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
