### PR TITLE
fix(config): alias the language names Partner Center spells differently

### DIFF
--- a/store-publisher.config.json
+++ b/store-publisher.config.json
@@ -89,7 +89,10 @@
       "internal": "bn",
       "cws": "bn",
       "amo": null,
-      "name": "Bengali"
+      "name": "Bengali",
+      "altNames": [
+        "Bangla"
+      ]
     },
     {
       "internal": "ca",
@@ -294,7 +297,10 @@
       "internal": "sw",
       "cws": "sw",
       "amo": null,
-      "name": "Swahili"
+      "name": "Swahili",
+      "altNames": [
+        "Kiswahili"
+      ]
     },
     {
       "internal": "th",

--- a/tests/store-publisher-config.test.js
+++ b/tests/store-publisher-config.test.js
@@ -59,6 +59,27 @@ describe('store-publisher.config.json', () => {
     expect(config.locales.filter(l => l.amo).length).toBe(28);
   });
 
+  // Store dropdowns do not agree on language names, and a lookup that only knows
+  // ours fails silently on exactly the locales that need an alias. Verified
+  // against a real Partner Center menu: it writes Bangla, Kiswahili and
+  // Norwegian (Bokmål) where we write Bengali, Swahili and Norwegian.
+  test('locales whose store name differs from ours carry an alias', () => {
+    const alts = Object.fromEntries(
+      config.locales.map((l) => [l.internal, l.altNames || []]));
+    expect(alts.bn).toContain('Bangla');
+    expect(alts.sw).toContain('Kiswahili');
+    expect(alts.nb).toContain('Norwegian (Bokmål)');
+  });
+
+  // Filipino is offered by the Chrome Web Store and not by Partner Center, so it
+  // is the one locale that can never have an Edge listing. Recorded here because
+  // a future "why is tl missing" is otherwise a research task from scratch.
+  test('Filipino is still configured, even though Edge does not offer it', () => {
+    const tl = config.locales.find((l) => l.internal === 'tl');
+    expect(tl.cws).toBe('fil');
+    expect(tl.name).toBe('Filipino');
+  });
+
   // The naming quirk that used to be a special case in the tool's code. The
   // publisher resolves {LANG} from fileCode when present, so these two facts
   // together are what makes dist/'s PromoCN.txt reachable.


### PR DESCRIPTION
Reading a real **"Add a language"** menu against our locale table turned up three mismatches, and the first two would have failed silently on exactly the locales that need an alias most.

| we write | Partner Center writes |
|---|---|
| Bengali | **Bangla** |
| Swahili | **Kiswahili** |
| Norwegian | Norwegian (Bokmål) — already aliased |

Both now carry an `altName`, which is the mechanism that already existed for the CWS dropdown. `nb` was matching *through* it all along, which is what made the pattern obvious — and what exposed that the driver's `selectLanguage` was only checking `locale.name` (fixed in the paired publisher PR).

## The third is not fixable here

**Filipino is not on Partner Center's menu at all.** Its 41 languages come from the package's `_locales`, and ours that is missing simply cannot have an Edge listing.

Recorded as a test rather than left for someone to rediscover — a future *"why is `tl` missing"* is otherwise a research task from scratch.

## Verification

- `npx jest` — 857 passing (27 suites).
- `build.py` + `validate_build.py` clean over 3 targets; tree unchanged after a build.

Paired with `dlamarre-dev/store-listing-publisher#6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
