### PR TITLE
fix(build): drop the whole cross-promotion, not just its dead link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,13 @@ follow from that and are easy to get wrong:
   a store URL only exists once the listing is published. `inject_popup_urls`
   then *removes* the block that would link nowhere (`strip_block`) rather than
   ship a dead link or an unsubstituted `__REVIEW_URL__`; `build_marketing` drops
-  the promo line carrying an unresolved `__AF_STORE_URL__` for the same reason.
+  the **whole cross-promotion section** carrying an unresolved `__AF_STORE_URL__`
+  (`drop_cross_promo`) for the same reason. Whole, not just the link line: that is
+  what it used to do, and it left the heading and the pitch behind. It went
+  unnoticed while the version history followed them; once the history was removed
+  (§6) the Edge listing simply ended on "AI Folders is the natural next step" with
+  nothing to click. `validate_build.py` fails a promo text whose last emoji
+  heading has no link under it, so the orphan cannot come back quietly.
   Filling the URL in brings both back on the next build — nothing to remember.
 - **`validate_build.py` now also walks `marketing_<target>/`.** It never did, and
   that was survivable only while every promo placeholder was always substituted.
@@ -787,7 +793,9 @@ already waiting for it, and each turns something on by itself.
 1. `build.py` → `review_url_edge` and `af_download_url_edge` (GF only). The
    review banner and the AI Folders promo banner are *removed* from the Edge
    build while these are empty — `strip_block` — and come back on the next build.
-   The same emptiness drops the `__AF_STORE_URL__` promo line.
+   The same emptiness drops the whole `__AF_STORE_URL__` cross-promotion section
+   from the Edge promo texts — filling the URL in brings it back on the next
+   build, in all 43 languages, with no other edit.
 2. `docs/site/app.js` → `LINKS.edge` and `LINKS.gemEdge`. One edit lights the
    button in all five places at once (nav, hero, Gemini card, final CTA, both
    footers), because `stores()` is the only thing that decides.

--- a/build.py
+++ b/build.py
@@ -60,6 +60,10 @@ EXTENSION_CONFIG = {
 # NUMBER instead — the one part that stays put in all 43 languages.
 HISTORY_LINE = re.compile(r"\d+\.\d")
 
+# The heading of the "also available" cross-promotion, as an emoji rather than as
+# a word: the wording is translated 43 ways and the emoji is not.
+CROSS_PROMO_HEADING = "\U0001f916"
+
 # Messages that exist only to be swapped in for some target. They are never
 # shipped under their own name — patch_locales drops them from every build.
 BUILD_ONLY_MESSAGES = ["syncFavoritesTooltip"]
@@ -284,6 +288,42 @@ def run_tests(assume_yes=False, force=False):
 # Extension builds
 # ---------------------------------------------------------------------------
 
+def drop_cross_promo(text, where):
+    """Removes the whole "also available" section when there is no store URL yet.
+
+    The popup's equivalent is strip_block: a brand-new store product has no public
+    page until it is published, so the link cannot be written and the block that
+    would carry it is removed instead.
+
+    Dropping only the line with the placeholder — which is what this used to do —
+    leaves the heading and the pitch behind. That was survivable while the version
+    history followed them and the amputation sat mid-document; with the history
+    gone (see CLAUDE.md §6) the listing now ENDS on "AI Folders is the natural next
+    step" and no way to get it, which is worse than not mentioning it at all.
+
+    The section is found from the placeholder backwards to the nearest heading
+    above it, headings being the emoji-led lines this text is built from. The emoji
+    is the marker because it is the one part that survives translation — the same
+    reason the version history is found by its megaphone. It appears twice per
+    file, once as a feature bullet and once as this heading, so the LAST one before
+    the link is the one that starts the section.
+    """
+    lines = text.split("\n")
+    link = next(i for i, ln in enumerate(lines) if "__AF_STORE_URL__" in ln)
+    heads = [i for i, ln in enumerate(lines[:link]) if CROSS_PROMO_HEADING in ln]
+    if not heads:
+        sys.exit(f"{where}: no {CROSS_PROMO_HEADING} heading above the "
+                 f"__AF_STORE_URL__ link, so the cross-promotion section cannot be "
+                 f"located. Dropping the link alone would publish a heading and a "
+                 f"pitch with no way to act on them.")
+    start = heads[-1]
+    # The blank line that separated it from the section above goes too, or the
+    # text ends on one.
+    while start > 0 and not lines[start - 1].strip():
+        start -= 1
+    return "\n".join(lines[:start] + lines[link + 1:]).rstrip() + "\n"
+
+
 def strip_block(html, element_id):
     """Removes a whole `<div id="...">...</div>` block from popup.html.
 
@@ -496,12 +536,7 @@ def build_marketing(ext_name, cfg, target_name, target):
                 if af_url:
                     content = content.replace("__AF_STORE_URL__", af_url)
                 else:
-                    # No listing to point at on this store yet. Drop the line
-                    # rather than publish the placeholder — nothing here walks
-                    # marketing_*/ looking for unresolved placeholders, so this
-                    # would otherwise reach the store as literal text.
-                    content = "\n".join(ln for ln in content.split("\n")
-                                        if "__AF_STORE_URL__" not in ln)
+                    content = drop_cross_promo(content, f"{ext_name}/{fn}")
                 modified = True
 
             # Only the listing descriptions are capped; the screenshots dir and

--- a/tools/validate_build.py
+++ b/tools/validate_build.py
@@ -29,6 +29,10 @@ EXPECTED_LOCALES = 43
 # from Partner Center comes after a submission.
 DESCRIPTION_MAX = {"edge": 10000}
 
+# The heading of the "also available" cross-promotion, matched by its emoji: the
+# wording is translated 43 ways and the emoji is not.
+CROSS_PROMO_HEADING = "🤖"
+
 failures = []
 
 
@@ -135,6 +139,25 @@ def check_marketing_placeholders(ext, browser):
             if limit and name.lower().startswith("promo") and len(content) > limit:
                 fail(f"{ext}/marketing_{browser}/{name}: {len(content)} chars, "
                      f"over the {limit} the store accepts")
+
+            # A section that pitches something and then offers no way to get it.
+            #
+            # The cross-promotion is dropped whole on a store where the other
+            # product has no listing yet (build.py, drop_cross_promo); dropping
+            # only its link leaves the heading and the pitch behind, which is what
+            # the build used to do. It went unnoticed while the version history
+            # followed and the gap sat mid-document — with the history gone, the
+            # listing simply ended on an invitation with nothing to click.
+            #
+            # Headings are emoji-led here, so the check is too: the wording is
+            # translated 43 ways and the emoji is not.
+            if name.lower().startswith("promo"):
+                lines = content.split(chr(10))
+                heads = [i for i, ln in enumerate(lines) if CROSS_PROMO_HEADING in ln]
+                if heads and not any("http" in ln for ln in lines[heads[-1]:]):
+                    fail(f"{ext}/marketing_{browser}/{name}: ends on a "
+                         f"'{lines[heads[-1]][:40]}' section with no link in it — "
+                         f"a pitch with nothing to act on")
 
 
 def check_zip(ext, version):


### PR DESCRIPTION
Edge has no AI Folders listing yet, so `af_download_url_edge` is empty and the build
removes what would be a link to nowhere. It removed **only the line** carrying the
placeholder — leaving the heading and the pitch behind:

```
🤖 ALSO AVAILABLE: AI Folders — THE MULTI-PLATFORM UPGRADE

Interested in Gemini Folders but also use ChatGPT…? AI Folders is the natural next
step: one extension to organize conversations across all your AI tools…
```

…and then nothing.

That was survivable while the version history followed it and the gap sat
mid-document. **Removing the history this morning made it the last thing a reader of
the Edge listing sees** — an invitation with nothing to act on, which is worse than
not mentioning the other product at all.

### `drop_cross_promo`

Removes the section: from the heading above the link down to the link itself, plus
the blank line that separated it from the section before.

Found by the heading's **emoji** rather than its words, for the same reason the
version history is found by its megaphone — the wording is translated 43 ways and
the emoji is not. It appears twice per file (once as a feature bullet), so the last
one before the link is the one that starts the section. No heading above the link is
a hard failure rather than a silent fallback: dropping the line alone is precisely
the behaviour being replaced.

### The popup side was already right

`strip_block` removes `afPromoBanner` and `reviewBanner` from the Edge build
entirely — both are absent from `dist/gemini-folders/edge/popup.html`. Only the
store text had the orphan.

### Guard

`validate_build.py` now fails a promo text whose last emoji heading has no link
under it. **Verified by ablation**: restoring the old line-drop fails all 43 Gemini
Folders Edge texts and nothing else. (My first ablation attempt silently patched
nothing and reported a clean run — worth saying, since that is exactly how a guard
gets believed without being tested.)

Filling `af_download_url_edge` in brings the whole section back on the next build,
in all 43 languages, with no other edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)