### PR TITLE
fix: use the canonical Edge store URLs, not the French ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -787,8 +787,8 @@ python amo/amo_publish.py --item <slug> --texts --images --apply
 
 Both cleared certification on 31/08/2026:
 
-- Gemini Folders — <https://microsoftedge.microsoft.com/addons/detail/dossiers-gemini-organise/ggippfdnnpodobohgekkjlfdgnkbccge>
-- AI Folders — <https://microsoftedge.microsoft.com/addons/detail/dossiers-ia-organisez-co/ikjbhgikmlcghjnbhaemgfhlbeaiddan>
+- Gemini Folders — <https://microsoftedge.microsoft.com/addons/detail/ggippfdnnpodobohgekkjlfdgnkbccge>
+- AI Folders — <https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan>
 
 Everything that had been built and left gated on those URLs turned on by pasting
 them in, which was the point of gating rather than branching:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A family of lightweight, multilingual browser extensions to **organize your AI c
 
 [![Available in the Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-Available-blue?logo=googlechrome)](https://chromewebstore.google.com/detail/ai-folders/kjmgfajofolnfeaahchpmkpecfimcppf)
 [![Available on Firefox Add-ons](https://img.shields.io/badge/Firefox_Add--ons-Available-orange?logo=firefox)](https://addons.mozilla.org/firefox/addon/ai_folders/)
-[![Available on Microsoft Edge Add-ons](https://img.shields.io/badge/Edge_Add--ons-Available-0078D7?logo=microsoftedge)](https://microsoftedge.microsoft.com/addons/detail/dossiers-ia-organisez-co/ikjbhgikmlcghjnbhaemgfhlbeaiddan)
+[![Available on Microsoft Edge Add-ons](https://img.shields.io/badge/Edge_Add--ons-Available-0078D7?logo=microsoftedge)](https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan)
 
 ### Supported platforms
 | Platform                       | Folders | Quick Save | Prompt Injection |
@@ -47,7 +47,7 @@ A family of lightweight, multilingual browser extensions to **organize your AI c
 
 [![Available in the Chrome Web Store](https://img.shields.io/badge/Chrome_Web_Store-Available-blue?logo=googlechrome)](https://chromewebstore.google.com/detail/gemini-folders/jffchdehoapigpmifkmleglfimjiilik)
 [![Available on Firefox Add-ons](https://img.shields.io/badge/Firefox_Add--ons-Available-orange?logo=firefox)](https://addons.mozilla.org/firefox/addon/gemini_folders/)
-[![Available on Microsoft Edge Add-ons](https://img.shields.io/badge/Edge_Add--ons-Available-0078D7?logo=microsoftedge)](https://microsoftedge.microsoft.com/addons/detail/dossiers-gemini-organise/ggippfdnnpodobohgekkjlfdgnkbccge)
+[![Available on Microsoft Edge Add-ons](https://img.shields.io/badge/Edge_Add--ons-Available-0078D7?logo=microsoftedge)](https://microsoftedge.microsoft.com/addons/detail/ggippfdnnpodobohgekkjlfdgnkbccge)
    
 ---
 
@@ -97,12 +97,12 @@ A family of lightweight, multilingual browser extensions to **organize your AI c
 **AI Folders:**
 👉 **[Install for Google Chrome](https://chromewebstore.google.com/detail/ai-folders/kjmgfajofolnfeaahchpmkpecfimcppf)**
 👉 **[Install for Mozilla Firefox](https://addons.mozilla.org/firefox/addon/ai_folders/)**
-👉 **[Install for Microsoft Edge](https://microsoftedge.microsoft.com/addons/detail/dossiers-ia-organisez-co/ikjbhgikmlcghjnbhaemgfhlbeaiddan)**
+👉 **[Install for Microsoft Edge](https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan)**
 
 **Gemini Folders:**
 👉 **[Install for Google Chrome](https://chromewebstore.google.com/detail/gemini-folders/jffchdehoapigpmifkmleglfimjiilik)**
 👉 **[Install for Mozilla Firefox](https://addons.mozilla.org/firefox/addon/gemini_folders/)**
-👉 **[Install for Microsoft Edge](https://microsoftedge.microsoft.com/addons/detail/dossiers-gemini-organise/ggippfdnnpodobohgekkjlfdgnkbccge)**
+👉 **[Install for Microsoft Edge](https://microsoftedge.microsoft.com/addons/detail/ggippfdnnpodobohgekkjlfdgnkbccge)**
 
 ### Option 2: Developer Mode (Manual Installation)
 

--- a/build.py
+++ b/build.py
@@ -38,10 +38,10 @@ EXTENSION_CONFIG = {
         # strip_review_banner); filling it in brings the banner back by itself.
         # Edge has no separate reviews page — they sit at the bottom of the
         # listing — so the review link is the listing itself.
-        "review_url_edge":         "https://microsoftedge.microsoft.com/addons/detail/dossiers-gemini-organise/ggippfdnnpodobohgekkjlfdgnkbccge",
+        "review_url_edge":         "https://microsoftedge.microsoft.com/addons/detail/ggippfdnnpodobohgekkjlfdgnkbccge",
         "af_download_url_chrome":  "https://chromewebstore.google.com/detail/ai-folders/kjmgfajofolnfeaahchpmkpecfimcppf",
         "af_download_url_firefox": "https://addons.mozilla.org/firefox/addon/ai_folders/",
-        "af_download_url_edge":    "https://microsoftedge.microsoft.com/addons/detail/dossiers-ia-organisez-co/ikjbhgikmlcghjnbhaemgfhlbeaiddan",
+        "af_download_url_edge":    "https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan",
     },
     "ai-folders": {
         "firefox_gecko_id":   "aifolders@dlamarre-dev.github.io",
@@ -52,7 +52,7 @@ EXTENSION_CONFIG = {
         "review_url_chrome":  "https://chromewebstore.google.com/detail/ai-folders/kjmgfajofolnfeaahchpmkpecfimcppf/reviews",
         "review_url_firefox": "https://addons.mozilla.org/firefox/addon/ai_folders/reviews/",
         # Same as above: the listing page, reviews being part of it.
-        "review_url_edge":    "https://microsoftedge.microsoft.com/addons/detail/dossiers-ia-organisez-co/ikjbhgikmlcghjnbhaemgfhlbeaiddan",
+        "review_url_edge":    "https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan",
     },
 }
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -46,7 +46,7 @@ AI Folders solves the problem of losing track of conversations across multiple A
 
 - Chrome Web Store: https://chromewebstore.google.com/detail/ai-folders/kjmgfajofolnfeaahchpmkpecfimcppf
 - Firefox Add-ons: https://addons.mozilla.org/firefox/addon/ai_folders/
-- Microsoft Edge Add-ons: https://microsoftedge.microsoft.com/addons/detail/dossiers-ia-organisez-co/ikjbhgikmlcghjnbhaemgfhlbeaiddan
+- Microsoft Edge Add-ons: https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan
 - Source code: https://github.com/dlamarre-dev/AI-Gemini-Folders
 
 ## Also available
@@ -55,7 +55,7 @@ AI Folders solves the problem of losing track of conversations across multiple A
 
 - Chrome: https://chromewebstore.google.com/detail/gemini-folders/jffchdehoapigpmifkmleglfimjiilik
 - Firefox: https://addons.mozilla.org/firefox/addon/gemini_folders/
-- Microsoft Edge: https://microsoftedge.microsoft.com/addons/detail/dossiers-gemini-organise/ggippfdnnpodobohgekkjlfdgnkbccge
+- Microsoft Edge: https://microsoftedge.microsoft.com/addons/detail/ggippfdnnpodobohgekkjlfdgnkbccge
 
 ## Technical details
 

--- a/docs/site/app.js
+++ b/docs/site/app.js
@@ -15,8 +15,8 @@
     firefox: "https://addons.mozilla.org/firefox/addon/ai_folders/",
     gemChrome: "https://chromewebstore.google.com/detail/gemini-folders/jffchdehoapigpmifkmleglfimjiilik",
     gemFirefox: "https://addons.mozilla.org/firefox/addon/gemini_folders/",
-    edge: "https://microsoftedge.microsoft.com/addons/detail/dossiers-ia-organisez-co/ikjbhgikmlcghjnbhaemgfhlbeaiddan",
-    gemEdge: "https://microsoftedge.microsoft.com/addons/detail/dossiers-gemini-organise/ggippfdnnpodobohgekkjlfdgnkbccge",
+    edge: "https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan",
+    gemEdge: "https://microsoftedge.microsoft.com/addons/detail/ggippfdnnpodobohgekkjlfdgnkbccge",
     github: "https://github.com/dlamarre-dev/AI-Gemini-Folders"
   };
 


### PR DESCRIPTION
The URLs shipped in 4.6.2 / 1.7.2 carried a **localized slug**:

```
https://microsoftedge.microsoft.com/addons/detail/dossiers-gemini-organise/ggipp…
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^
```

That is the address Partner Center shows to a French session. The id is the same and
the slug is not part of the identity — so sending every language to a French-slugged
link is wrong for the other 42.

| | |
|---|---|
| AI Folders | `https://microsoftedge.microsoft.com/addons/detail/ikjbhgikmlcghjnbhaemgfhlbeaiddan` |
| Gemini Folders | `https://microsoftedge.microsoft.com/addons/detail/ggippfdnnpodobohgekkjlfdgnkbccge` |

Replaced in all five places that carry a store URL: `build.py`'s review and
cross-promotion links, the site's `LINKS`, `llms.txt`, the README badges and install
links, and the note in CLAUDE.md §12c. A repo-wide grep now returns only the two
canonical forms.

862 tests, six packages built and validated; the built Edge popup and promo texts
both carry the corrected links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)